### PR TITLE
Add basic lint of config file (yaml)

### DIFF
--- a/.github/workflows/ci_yamllint.yaml
+++ b/.github/workflows/ci_yamllint.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: "CI: lint MotoROS2 config"
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: karancode/yamllint-github-action@v2.1.1
+        with:
+          yamllint_file_or_dir: 'config'
+          yamllint_config_filepath: 'config/.yamllint'
+          yamllint_strict: true
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/motoros2_config.yaml
+++ b/config/motoros2_config.yaml
@@ -150,7 +150,7 @@ update_periods:
   # This value should be <= to action_feedback_publisher_period as executor_sleep_period
   # is the rate at which the action-feedback timer is checked. If the value for
   # action_feedback_publisher_period is < executor_sleep_period, it will effectively
-  # be treated as having the same value executor_sleep_period at runtime. 
+  # be treated as having the same value executor_sleep_period at runtime.
   #
   # DEFAULT: 10 milliseconds
   executor_sleep_period: 10


### PR DESCRIPTION
As per subject.

Prevents us from merging YAML which doesn't actually follow our own formatting rules (which we seem to have done already: c0a8fee7b795af2dd31a4928dca49d4cb236490a).
