### PR TITLE
Add basic Markdown linter

### DIFF
--- a/.github/workflows/ci_md_lint.yaml
+++ b/.github/workflows/ci_md_lint.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: "CI: lint Markdown"
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DavidAnson/markdownlint-cli2-action@v10
+      with:
+        globs: "**/*.md"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023, Yaskawa America, Inc.
+# SPDX-FileCopyrightText: 2023, Delft University of Technology
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+# we disable this because we use semantic line breaks (one-sentence-per-line,
+# specifically) so we can't put a maximum length on lines.
+MD013: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,28 +20,28 @@ The old `motoros2_interfaces-beta1` repository will also be *archived* and will 
 
 Changes:
 
- - Significantly reduced shutdown time: MotoROS2 now takes approximately 4 seconds to shutdown after it detects the micro-ROS Agent has disconnected (after the default timeout, which is set to 10 seconds)
- - Improved publisher performance (`RobotStatus`, `JointState`, TF)
- - Migrated motion-related services to dedicated executor
- - MotoROS2 now publishes all active alarms & errors on `robot_status`, as opposed to only the one raised most recently
- - `reset_error` now also resets MotoROS2 internal errors
- - Extended `FollowJointTrajectory` goal validation. MotoROS2 now requires:
-   - positive and non-zero durations for all segments
-   - monotonically increasing timestamps on all trajectory points
-   - `positions` and `velocities` for all joints
-   - zero velocity and acceleration for the last trajectory point
- - Extended config file loader to verify names are present for all joints in a group when providing custom joint names
- - Fixed incorrect `result_code` returned by `start_traj_mode`/`start_point_queue_mode`: services now return `MotionReadyEnum::READY` (ie: `1`) instead of `0` on success
- - Updated Visual Studio solution to support Foxy builds
- - Updated Visual Studio solution to support Galactic builds
- - Migrated platform-specific functionality to a common library
- - Migrated custom string handling code to corresponding `rcutils` functionality
- - Switched to using M+ `libmicroros` configuration header
- - Corrected capitalization of "micro-ROS" in the application info struct
+- Significantly reduced shutdown time: MotoROS2 now takes approximately 4 seconds to shutdown after it detects the micro-ROS Agent has disconnected (after the default timeout, which is set to 10 seconds)
+- Improved publisher performance (`RobotStatus`, `JointState`, TF)
+- Migrated motion-related services to dedicated executor
+- MotoROS2 now publishes all active alarms & errors on `robot_status`, as opposed to only the one raised most recently
+- `reset_error` now also resets MotoROS2 internal errors
+- Extended `FollowJointTrajectory` goal validation. MotoROS2 now requires:
+  - positive and non-zero durations for all segments
+  - monotonically increasing timestamps on all trajectory points
+  - `positions` and `velocities` for all joints
+  - zero velocity and acceleration for the last trajectory point
+- Extended config file loader to verify names are present for all joints in a group when providing custom joint names
+- Fixed incorrect `result_code` returned by `start_traj_mode`/`start_point_queue_mode`: services now return `MotionReadyEnum::READY` (ie: `1`) instead of `0` on success
+- Updated Visual Studio solution to support Foxy builds
+- Updated Visual Studio solution to support Galactic builds
+- Migrated platform-specific functionality to a common library
+- Migrated custom string handling code to corresponding `rcutils` functionality
+- Switched to using M+ `libmicroros` configuration header
+- Corrected capitalization of "micro-ROS" in the application info struct
 
 Notices:
 
- - Switched MotoROS2 to the `Apache-2.0` open-source license (from `BSD-3-Clause`)
+- Switched MotoROS2 to the `Apache-2.0` open-source license (from `BSD-3-Clause`)
 
 ## 0.0.15 (2022-11-30)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 All contributions made to this repository will be under the `Apache-2.0` License, as dictated by that [license](http://www.apache.org/licenses/LICENSE-2.0.html):
 
-~~~
+```text
 5. Submission of Contributions. Unless You explicitly state otherwise,
    any Contribution intentionally submitted for inclusion in the Work
    by You to the Licensor shall be under the terms and conditions of
@@ -15,4 +15,4 @@ All contributions made to this repository will be under the `Apache-2.0` License
    Notwithstanding the above, nothing herein shall supersede or modify
    the terms of any separate license agreement you may have executed
    with Licensor regarding such Contributions.
-~~~
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ SPDX-FileCopyrightText: 2023, Delft University of Technology
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
+# Contributing
+
 All contributions made to this repository will be under the `Apache-2.0` License, as dictated by that [license](http://www.apache.org/licenses/LICENSE-2.0.html):
 
 ```text


### PR DESCRIPTION
As per subject.

All default rules, except we disable `MD013` (line length): we use [semantic line breaks](https://sembr.org) (one-sentence-per-line, specifically) so we can't put a maximum length on lines.

Commits after 5957914835133924b70215eeb79b8bee9bc52eaa fix problems with our `.md` files the linter flagged.
