### PR TITLE
Replace unicode (c) with 'ASCII (c)'

### DIFF
--- a/src/Quaternion_Conversion.c
+++ b/src/Quaternion_Conversion.c
@@ -49,7 +49,7 @@
 //
 // The MIT License
 //
-// Copyright © 2010 - 2020 three.js authors
+// Copyright (c) 2010 - 2020 three.js authors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this softwareand associated documentation files(the "Software"), to deal

--- a/src/Quaternion_Conversion.h
+++ b/src/Quaternion_Conversion.h
@@ -51,7 +51,7 @@
 //
 // The MIT License
 //
-// Copyright © 2010 - 2020 three.js authors
+// Copyright (c) 2010 - 2020 three.js authors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this softwareand associated documentation files(the "Software"), to deal


### PR DESCRIPTION
As per subject.

I'm trying out some code quality / static analysis tools, and they fail to parse the unicode `©`.
