### PR TITLE
Replace in-line tabs with spaces

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -23,7 +23,7 @@ control_msgs__action__FollowJointTrajectory_FeedbackMessage feedback_FollowJoint
 //Static Memory (used for FJT goal storage)
 
 //TODO: shrink this once I have found a good buffer size
-#define SIZEOF_BUFFER_FJT_GOAL		(2000000)
+#define SIZEOF_BUFFER_FJT_GOAL (2000000)
 UINT8 Ros_StaticAllocationBuffer_FJTgoal[SIZEOF_BUFFER_FJT_GOAL];
 
 

--- a/src/ActionServer_FJT.h
+++ b/src/ActionServer_FJT.h
@@ -8,8 +8,8 @@
 #ifndef MOTOROS2_ACTION_SERVER_FJT_H
 #define MOTOROS2_ACTION_SERVER_FJT_H
 
-#define MAX_NUMBER_OF_POINTS_PER_TRAJECTORY	200
-#define MIN_NUMBER_OF_POINTS_PER_TRAJECTORY	2	//current position and destination
+#define MAX_NUMBER_OF_POINTS_PER_TRAJECTORY 200
+#define MIN_NUMBER_OF_POINTS_PER_TRAJECTORY 2   //current position and destination
 
 #define DEFAULT_FJT_GOAL_POSITION_TOLERANCE  (0.01) //radians per axis or meters per axis
 #define DEFAULT_FJT_GOAL_TIME_TOLERANCE      (500000000LL) //nanoseconds (0.5 seconds)

--- a/src/CommunicationExecutor.h
+++ b/src/CommunicationExecutor.h
@@ -8,21 +8,21 @@
 #ifndef MOTOROS2_COMMUNICATION_EXECUTOR_H
 #define MOTOROS2_COMMUNICATION_EXECUTOR_H
 
-#define PERIOD_COMMUNICATION_PING_AGENT_MS					5000
+#define PERIOD_COMMUNICATION_PING_AGENT_MS                  5000
 
 // total number of handles =
-//		timers +                                            2
-//		action_server +                                     1
-//		service reset                                       1
-//		service start_traj_mode                             1
-//		service start_point_queue_mode                      1
-//		service stop_traj_mode                              1
-//		service queue_traj_point                            1
-//		service select_tool                                 1
+//      timers +                                            2
+//      action_server +                                     1
+//      service reset                                       1
+//      service start_traj_mode                             1
+//      service start_point_queue_mode                      1
+//      service stop_traj_mode                              1
+//      service queue_traj_point                            1
+//      service select_tool                                 1
 #define QUANTITY_OF_HANDLES_FOR_MOTION_EXECUTOR             (9)
 
 // total number of handles =
-//		service read & write I/O +                          6
+//      service read & write I/O +                          6
 #define QUANTITY_OF_HANDLES_FOR_IO_EXECUTOR                 (6)
 
 typedef struct

--- a/src/ConfigFile.h
+++ b/src/ConfigFile.h
@@ -11,53 +11,53 @@
 #define CONFIG_FILE_NAME                "motoros2_config.yaml"
 #define FORMAT_CONFIG_FILE_BACKUP       "%s\\%s.%04d%02d%02d_%02d%02d%02d" //Example: "MPUSB0\motoros2_config.yaml.202207029_081011"
 
-#define MAX_YAML_STRING_LEN				128
+#define MAX_YAML_STRING_LEN             128
 
-#define DEFAULT_ROS_DOMAIN_ID			0
-#define MIN_ROS_DOMAIN_ID_LINUX			0
-#define MAX_ROS_DOMAIN_ID_LINUX			101
+#define DEFAULT_ROS_DOMAIN_ID           0
+#define MIN_ROS_DOMAIN_ID_LINUX         0
+#define MAX_ROS_DOMAIN_ID_LINUX         101
 
-#define DEFAULT_NODE_NAME				"motoman" //will be suffixed with MAC ID
+#define DEFAULT_NODE_NAME               "motoman" //will be suffixed with MAC ID
 
-#define DEFAULT_NODE_NAMSPACE			""
+#define DEFAULT_NODE_NAMSPACE           ""
 
-#define DEFAULT_SYNCTIME				TRUE
+#define DEFAULT_SYNCTIME                TRUE
 
-#define DEFAULT_PUBLISH_TF				TRUE
+#define DEFAULT_PUBLISH_TF              TRUE
 
-#define DEFAULT_NAMESPACE_TF			TRUE
+#define DEFAULT_NAMESPACE_TF            TRUE
 
 // NOTE: We do not prefix joints by the "motoman Grp ID" here, but use the generic
 // group & joint names instead to avoid the OEM-specific names.
-#define DEFAULT_JOINT_NAME_FMT			"group_%d/joint_%d"
+#define DEFAULT_JOINT_NAME_FMT          "group_%d/joint_%d"
 
-#define DEFAULT_LOG_TO_STDOUT			FALSE
+#define DEFAULT_LOG_TO_STDOUT           FALSE
 
-#define DEFAULT_EXECUTOR_SLEEP_PERIOD	10 //ms
+#define DEFAULT_EXECUTOR_SLEEP_PERIOD   10 //ms
 #define MIN_EXECUTOR_SLEEP_PERIOD       1
 #define MAX_EXECUTOR_SLEEP_PERIOD       100
 
-#define DEFAULT_FEEDBACK_PUBLISH_PERIOD	20 //ms
+#define DEFAULT_FEEDBACK_PUBLISH_PERIOD 20 //ms
 #define MIN_FEEDBACK_PUBLISH_PERIOD     1
 #define MAX_FEEDBACK_PUBLISH_PERIOD     100
 
-#define DEFAULT_CONTROLLER_IO_PERIOD	10 //ms
+#define DEFAULT_CONTROLLER_IO_PERIOD    10 //ms
 #define MIN_CONTROLLER_IO_PERIOD        1
 #define MAX_CONTROLLER_IO_PERIOD        100
 
-#define DEFAULT_QOS_ROBOT_STATUS		ROS_QOS_PROFILE_SENSOR_DATA
+#define DEFAULT_QOS_ROBOT_STATUS        ROS_QOS_PROFILE_SENSOR_DATA
 
-#define DEFAULT_QOS_JOINT_STATES		ROS_QOS_PROFILE_SENSOR_DATA
+#define DEFAULT_QOS_JOINT_STATES        ROS_QOS_PROFILE_SENSOR_DATA
 
-#define DEFAULT_QOS_TF					ROS_QOS_PROFILE_DEFAULT
+#define DEFAULT_QOS_TF                  ROS_QOS_PROFILE_DEFAULT
 
-#define DEFAULT_TF_FRAME_PREFIX			""
+#define DEFAULT_TF_FRAME_PREFIX         ""
 
 #define DEFAULT_STOP_MOTION_ON_DISCON   TRUE
 
 #define DEFAULT_ALLOW_CUSTOM_INFORM     FALSE
 
-#define DEFAULT_INFORM_JOB_NAME			"INIT_ROS"
+#define DEFAULT_INFORM_JOB_NAME         "INIT_ROS"
 
 // based on rmw/qos_profiles.h
 typedef enum
@@ -70,9 +70,9 @@ typedef enum
     ROS_QOS_PROFILE_SYSTEM_DEFAULT = 6,
 } Ros_QoS_Profile_Setting;
 
-#define DEFAULT_REMAP_RULES				""
-#define MAX_REMAP_RULE_NUM				16
-#define MAX_REMAP_RULE_LEN				256
+#define DEFAULT_REMAP_RULES             ""
+#define MAX_REMAP_RULE_NUM              16
+#define MAX_REMAP_RULE_LEN              256
 
 typedef struct
 {

--- a/src/ControllerStatusIO.c
+++ b/src/ControllerStatusIO.c
@@ -85,9 +85,9 @@ BOOL Ros_Controller_Initialize()
         if(groupIndex < g_Ros_Controller.numGroup)
         {
             // Determine if specific group exists and allocate memory for it
-            g_Ros_Controller.ctrlGroups[groupIndex] = Ros_CtrlGroup_Create(groupIndex,								//Zero based index of the group number(0 - 3)
-                                                                (groupIndex==(g_Ros_Controller.numGroup-1)),	//TRUE if this is the final group that is being initialized. FALSE if you plan to call this function again.
-                                                                g_Ros_Controller.interpolPeriod);		//Value of the interpolation period (ms) for the robot controller.
+            g_Ros_Controller.ctrlGroups[groupIndex] = Ros_CtrlGroup_Create(groupIndex,                       //Zero based index of the group number(0 - 3)
+                                                                (groupIndex==(g_Ros_Controller.numGroup-1)), //TRUE if this is the final group that is being initialized. FALSE if you plan to call this function again.
+                                                                g_Ros_Controller.interpolPeriod);            //Value of the interpolation period (ms) for the robot controller.
             if(g_Ros_Controller.ctrlGroups[groupIndex] != NULL)
             {
                 Ros_CtrlGroup_GetPulsePosCmd(g_Ros_Controller.ctrlGroups[groupIndex], g_Ros_Controller.ctrlGroups[groupIndex]->prevPulsePos); // set the current commanded pulse
@@ -267,28 +267,28 @@ BOOL Ros_Controller_IsValidGroupNo(int groupNo)
 //-------------------------------------------------------------------
 void Ros_Controller_StatusInit()
 {
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_MAJOR].ulAddr = 50010;		// Alarm
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_MINOR].ulAddr = 50011;		// Alarm
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_SYSTEM].ulAddr = 50012;		// Alarm
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_USER].ulAddr = 50013;			// Alarm
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ERROR].ulAddr = 50014;				// Error
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PLAY].ulAddr = 50054;				// Play
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_TEACH].ulAddr = 50053;				// Teach
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_REMOTE].ulAddr = 80011; //50056;	// Remote  // Modified E.M. 7/9/2013
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_OPERATING].ulAddr = 50070;			// Operating
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_HOLD].ulAddr = 50071;				// Hold
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_SERVO].ulAddr = 50073;   			// Servo ON
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ESTOP_EX].ulAddr = 80025;   		// External E-Stop
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ESTOP_PP].ulAddr = 80026;   		// Pendant E-Stop
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ESTOP_CTRL].ulAddr = 80027;   		// Controller E-Stop
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_MAJOR].ulAddr = 50010;       // Alarm
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_MINOR].ulAddr = 50011;       // Alarm
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_SYSTEM].ulAddr = 50012;      // Alarm
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ALARM_USER].ulAddr = 50013;        // Alarm
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ERROR].ulAddr = 50014;             // Error
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PLAY].ulAddr = 50054;              // Play
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_TEACH].ulAddr = 50053;             // Teach
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_REMOTE].ulAddr = 80011; //50056;   // Remote  // Modified E.M. 7/9/2013
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_OPERATING].ulAddr = 50070;         // Operating
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_HOLD].ulAddr = 50071;              // Hold
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_SERVO].ulAddr = 50073;             // Servo ON
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ESTOP_EX].ulAddr = 80025;          // External E-Stop
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ESTOP_PP].ulAddr = 80026;          // Pendant E-Stop
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_ESTOP_CTRL].ulAddr = 80027;        // Controller E-Stop
     g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_WAITING_ROS].ulAddr = IO_FEEDBACK_WAITING_MP_INCMOVE; // Job input signaling ready for external motion
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_INECOMODE].ulAddr = 50727;			// Energy Saving Mode
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_INECOMODE].ulAddr = 50727;         // Energy Saving Mode
 #if (YRC1000||YRC1000u)
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_STOP].ulAddr = 81702;			// PFL function stopped the motion
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_ESCAPE].ulAddr = 81703;			// PFL function escape from clamping motion
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_AVOIDING].ulAddr = 15120;		// PFL function avoidance operating
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_AVOID_JOINT].ulAddr = 15124;	// PFL function avoidance joint enabled
-    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_AVOID_TRANS].ulAddr = 15125;	// PFL function avoidance translation enabled
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_STOP].ulAddr = 81702;          // PFL function stopped the motion
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_ESCAPE].ulAddr = 81703;        // PFL function escape from clamping motion
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_AVOIDING].ulAddr = 15120;      // PFL function avoidance operating
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_AVOID_JOINT].ulAddr = 15124;   // PFL function avoidance joint enabled
+    g_Ros_Controller.ioStatusAddr[IO_ROBOTSTATUS_PFL_AVOID_TRANS].ulAddr = 15125;   // PFL function avoidance translation enabled
 #endif
     g_Ros_Controller.alarmCode = 0;
 

--- a/src/ControllerStatusIO.h
+++ b/src/ControllerStatusIO.h
@@ -8,35 +8,35 @@
 #ifndef MOTOROS2_CONTROLLER_STATUS_IO_H
 #define MOTOROS2_CONTROLLER_STATUS_IO_H
 
-#define IO_FEEDBACK_WAITING_MP_INCMOVE		11120  //output# 889
-#define IO_FEEDBACK_MP_INCMOVE_DONE			11121  //output# 890
-#define IO_FEEDBACK_INITIALIZATION_DONE		11122  //output# 891
-#define IO_FEEDBACK_CONTROLLERRUNNING		11123  //output# 892
-#define IO_FEEDBACK_AGENTCONNECTED			11124  //output# 893
-#define IO_FEEDBACK__						11125  //output# 894
-#define IO_FEEDBACK___						11126  //output# 895
-#define IO_FEEDBACK_FAILURE					11127  //output# 896
+#define IO_FEEDBACK_WAITING_MP_INCMOVE      11120  //output# 889
+#define IO_FEEDBACK_MP_INCMOVE_DONE         11121  //output# 890
+#define IO_FEEDBACK_INITIALIZATION_DONE     11122  //output# 891
+#define IO_FEEDBACK_CONTROLLERRUNNING       11123  //output# 892
+#define IO_FEEDBACK_AGENTCONNECTED          11124  //output# 893
+#define IO_FEEDBACK__                       11125  //output# 894
+#define IO_FEEDBACK___                      11126  //output# 895
+#define IO_FEEDBACK_FAILURE                 11127  //output# 896
 
-#define IO_FEEDBACK_RESERVED_1				11130  //output# 897
-#define IO_FEEDBACK_RESERVED_2				11131  //output# 898
-#define IO_FEEDBACK_RESERVED_3				11132  //output# 899
-#define IO_FEEDBACK_RESERVED_4				11133  //output# 900
-#define IO_FEEDBACK_RESERVED_5				11134  //output# 901
-#define IO_FEEDBACK_RESERVED_6				11135  //output# 902
-#define IO_FEEDBACK_RESERVED_7				11136  //output# 903
-#define IO_FEEDBACK_RESERVED_8				11137  //output# 904
+#define IO_FEEDBACK_RESERVED_1              11130  //output# 897
+#define IO_FEEDBACK_RESERVED_2              11131  //output# 898
+#define IO_FEEDBACK_RESERVED_3              11132  //output# 899
+#define IO_FEEDBACK_RESERVED_4              11133  //output# 900
+#define IO_FEEDBACK_RESERVED_5              11134  //output# 901
+#define IO_FEEDBACK_RESERVED_6              11135  //output# 902
+#define IO_FEEDBACK_RESERVED_7              11136  //output# 903
+#define IO_FEEDBACK_RESERVED_8              11137  //output# 904
 
-#define INVALID_TASK						-1
+#define INVALID_TASK                        -1
 
-#define MAX_CONTROLLABLE_GROUPS				8
+#define MAX_CONTROLLABLE_GROUPS             8
 
-#define MASK_ISALARM_ACTIVEALARM			0x02
-#define MASK_ISALARM_ACTIVEERROR			0x01
+#define MASK_ISALARM_ACTIVEALARM            0x02
+#define MASK_ISALARM_ACTIVEERROR            0x01
 
-#define MAX_ROBOT_CALIBRATION_FILES			32
+#define MAX_ROBOT_CALIBRATION_FILES         32
 
-#define MIN_VALID_TOOL_INDEX		0
-#define MAX_VALID_TOOL_INDEX		63
+#define MIN_VALID_TOOL_INDEX                0
+#define MAX_VALID_TOOL_INDEX                63
 
 typedef enum
 {
@@ -68,23 +68,23 @@ typedef enum
 
 typedef struct
 {
-    UINT16 interpolPeriod;									// Interpolation period of the controller
-    int numGroup;											// Actual number of defined group
-    //int numRobot;											// Actual number of defined robot
-    int totalAxesCount;										// Number of axes attached to the controller (all groups)
-    CtrlGroup* ctrlGroups[MAX_CONTROLLABLE_GROUPS];			// Array of the controller control group
+    UINT16 interpolPeriod;                                  // Interpolation period of the controller
+    int numGroup;                                           // Actual number of defined group
+    //int numRobot;                                         // Actual number of defined robot
+    int totalAxesCount;                                     // Number of axes attached to the controller (all groups)
+    CtrlGroup* ctrlGroups[MAX_CONTROLLABLE_GROUPS];         // Array of the controller control group
 
     // Controller Status
-    MP_IO_INFO ioStatusAddr[IO_ROBOTSTATUS_MAX];			// Array of Specific Input Address representing the I/O status
-    USHORT ioStatus[IO_ROBOTSTATUS_MAX];					// Array storing the current status of the controller
-    int alarmCode;											// Alarm number currently active
-    BOOL bStopMotion;										// Flag to stop motion
-    BOOL bPFLEnabled;										// Flag indicating that the controller has the PFL option enabled
-    BOOL bPFLduringRosMove;									// Flag to keep track PFL activation during RosMotion
-    BOOL bMpIncMoveError;									// Flag indicating that the incremental motion API failed
+    MP_IO_INFO ioStatusAddr[IO_ROBOTSTATUS_MAX];            // Array of Specific Input Address representing the I/O status
+    USHORT ioStatus[IO_ROBOTSTATUS_MAX];                    // Array storing the current status of the controller
+    int alarmCode;                                          // Alarm number currently active
+    BOOL bStopMotion;                                       // Flag to stop motion
+    BOOL bPFLEnabled;                                       // Flag indicating that the controller has the PFL option enabled
+    BOOL bPFLduringRosMove;                                 // Flag to keep track PFL activation during RosMotion
+    BOOL bMpIncMoveError;                                   // Flag indicating that the incremental motion API failed
     BOOL bPrevAlarmState;                                   // Flag indicating if there was an active ALARM during the last I/O cycle
 
-    int tidIncMoveThread;  									// ThreadId for sending the incremental move to the controller
+    int tidIncMoveThread;                                   // ThreadId for sending the incremental move to the controller
 } Controller;
 
 typedef struct
@@ -143,7 +143,7 @@ extern int Ros_Controller_GetAlarmCode();
 extern int Ros_Controller_GetActiveAlarmCodes(USHORT active_alarms[MAX_ALARM_COUNT + 1]);
 
 
-//#define DUMMY_SERVO_MODE 1	// Dummy servo mode is used for testing with Yaskawa debug controllers
+//#define DUMMY_SERVO_MODE 1    // Dummy servo mode is used for testing with Yaskawa debug controllers
 #ifdef DUMMY_SERVO_MODE
 #warning Dont forget to disable DUMMY_SERO_MODE when done testing
 #endif

--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -338,7 +338,7 @@ BOOL Ros_CtrlGroup_GetFBPulsePos(CtrlGroup* ctrlGroup, long pulsePos[MAX_PULSE_A
 
     //--------------------------------------------------------------------
     //NOTE: Do NOT apply any B axis compensation here.
-    //		This is actual feedback which is reported to the state server.
+    //      This is actual feedback which is reported to the state server.
     //--------------------------------------------------------------------
 
     return TRUE;

--- a/src/CtrlGroup.h
+++ b/src/CtrlGroup.h
@@ -17,11 +17,11 @@
 #define Q_LOCK_TIMEOUT 5000  //YRC1000 tick period is 0.2 ms
 #endif
 
-#define	Q_OFFSET_IDX( a, b, c )	(((a)+(b)) >= (c) ) ? ((a)+(b)-(c)) \
+#define Q_OFFSET_IDX( a, b, c ) (((a)+(b)) >= (c) ) ? ((a)+(b)-(c)) \
                 : ( (((a)+(b)) < 0 ) ? ((a)+(b)+(c)) : ((a)+(b)) )
 
-#define MAX_JOINT_NAME_LENGTH				32
-#define MAX_TF_FRAME_NAME_LENGTH			96
+#define MAX_JOINT_NAME_LENGTH               32
+#define MAX_TF_FRAME_NAME_LENGTH            96
 
 typedef struct
 {
@@ -43,10 +43,10 @@ typedef struct
 // jointMotionData values are in radian and joint order in sequential order
 typedef struct
 {
-    BOOL valid;						// this point has valid data
-    UINT64 time;					// time in millisecond
-    double pos[MP_GRP_AXES_NUM];	// position in radians
-    double vel[MP_GRP_AXES_NUM];	// velocity in radians/s
+    BOOL valid;                     // this point has valid data
+    UINT64 time;                    // time in millisecond
+    double pos[MP_GRP_AXES_NUM];    // position in radians
+    double vel[MP_GRP_AXES_NUM];    // velocity in radians/s
 } JointMotionData;
 
 //---------------------------------------------------------------
@@ -55,36 +55,36 @@ typedef struct
 //---------------------------------------------------------------
 typedef struct
 {
-    int groupNo;								// sequence group number
-    int numAxes;								// number of axis in the control group
-    MP_GRP_ID_TYPE groupId;						// control group ID
-    PULSE_TO_RAD pulseToRad;					// conversion ratio between pulse and radian
-    PULSE_TO_METER pulseToMeter;				// conversion ratio between pulse and meter (linear axis)
-    FB_PULSE_CORRECTION_DATA correctionData;	// compensation for axes coupling
-    MAX_INCREMENT_INFO maxInc;					// maximum increment per interpolation cycle
-    double maxSpeed[MP_GRP_AXES_NUM];			// maximum joint speed in radian/sec (rotational) or meter/sec (linear) (ROS joint-order)
-    int tool;									// selected tool for the motion
+    int groupNo;                                // sequence group number
+    int numAxes;                                // number of axis in the control group
+    MP_GRP_ID_TYPE groupId;                     // control group ID
+    PULSE_TO_RAD pulseToRad;                    // conversion ratio between pulse and radian
+    PULSE_TO_METER pulseToMeter;                // conversion ratio between pulse and meter (linear axis)
+    FB_PULSE_CORRECTION_DATA correctionData;    // compensation for axes coupling
+    MAX_INCREMENT_INFO maxInc;                  // maximum increment per interpolation cycle
+    double maxSpeed[MP_GRP_AXES_NUM];           // maximum joint speed in radian/sec (rotational) or meter/sec (linear) (ROS joint-order)
+    int tool;                                   // selected tool for the motion
 
-    Incremental_q inc_q;						// incremental queue
-    UINT64 q_time;								// time to which the queue has been processed
+    Incremental_q inc_q;                        // incremental queue
+    UINT64 q_time;                              // time to which the queue has been processed
 
-    JointMotionData* trajectoryIterator;		// joint motion command data in radian
-    JointMotionData* prevTrajectoryIterator;	// joint motion command data in radian
-    JointMotionData trajectoryToProcess[MAX_NUMBER_OF_POINTS_PER_TRAJECTORY];	// joint motion command data in radian to process
+    JointMotionData* trajectoryIterator;        // joint motion command data in radian
+    JointMotionData* prevTrajectoryIterator;    // joint motion command data in radian
+    JointMotionData trajectoryToProcess[MAX_NUMBER_OF_POINTS_PER_TRAJECTORY];   // joint motion command data in radian to process
 
-    BOOL hasDataToProcess;						// indicates that there is data to process
-    UINT64 timeLeftover_ms;						// Time left over after reaching the end of a trajectory to complete the interpolation period
-    long prevPulsePos[MAX_PULSE_AXES];			// The commanded pulse position that the trajectory starts at (Ros_MotionServer_StartTrajMode)
-    AXIS_MOTION_TYPE axisType;					// Indicates whether axis is rotary or linear
+    BOOL hasDataToProcess;                      // indicates that there is data to process
+    UINT64 timeLeftover_ms;                     // Time left over after reaching the end of a trajectory to complete the interpolation period
+    long prevPulsePos[MAX_PULSE_AXES];          // The commanded pulse position that the trajectory starts at (Ros_MotionServer_StartTrajMode)
+    AXIS_MOTION_TYPE axisType;                  // Indicates whether axis is rotary or linear
     char jointNames_userDefined[MP_GRP_AXES_NUM][MAX_JOINT_NAME_LENGTH]; //string name for each joint in 'moto' (non-sequential) joint order
 
-    BOOL bIsBaxisSlave;							// Indicates the B axis will automatically move to maintain orientation as other axes are moved
+    BOOL bIsBaxisSlave;                         // Indicates the B axis will automatically move to maintain orientation as other axes are moved
 
-    MP_COORD robotCalibrationToBaseFrame;		// Transform from [BF] > [RF] or [BF] > [base track origin]
+    MP_COORD robotCalibrationToBaseFrame;       // Transform from [BF] > [RF] or [BF] > [base track origin]
 
-    MP_GRP_ID_TYPE baseTrackGroupId;			// ID for the base track associated with this robot (-1 if no base track)
-    int baseTrackGroupIndex;					// Group index for the base track associated with this robot (-1 if no base track)
-    BASE_AXIS_INFO baseTrackInfo;				//
+    MP_GRP_ID_TYPE baseTrackGroupId;            // ID for the base track associated with this robot (-1 if no base track)
+    int baseTrackGroupIndex;                    // Group index for the base track associated with this robot (-1 if no base track)
+    BASE_AXIS_INFO baseTrackInfo;               //
 
     JOINT_FEEDBACK_SPEED_ADDRESSES speedFeedbackRegisterAddress; //CIO address for the registers containing feedback speed
 
@@ -105,9 +105,9 @@ typedef struct
 
 //Initialize specific control group. This should be called for each group connected to the robot
 //controller in numerical order.
-//	int groupNo: Zero based index of the group number (0-3)
-//	BOOL bIsLastGrpToInit: TRUE if this is the final group that is being initialized. FALSE if you plan to call this function again.
-//	float interpolPeriod: Value of the interpolation period (ms) for the robot controller.
+//  int groupNo: Zero based index of the group number (0-3)
+//  BOOL bIsLastGrpToInit: TRUE if this is the final group that is being initialized. FALSE if you plan to call this function again.
+//  float interpolPeriod: Value of the interpolation period (ms) for the robot controller.
 extern CtrlGroup* Ros_CtrlGroup_Create(int groupNo, BOOL bIsLastGrpToInit, float interpolPeriod);
 extern void Ros_CtrlGrp_Cleanup(CtrlGroup* ctrlGroup);
 

--- a/src/Debug.c
+++ b/src/Debug.c
@@ -8,9 +8,9 @@
 #include "MotoROS.h"
 
 
-#define DEBUG_UDP_PORT_NUMBER	21789
+#define DEBUG_UDP_PORT_NUMBER   21789
 
-#define MAX_DEBUG_MESSAGE_SIZE	1024
+#define MAX_DEBUG_MESSAGE_SIZE  1024
 
 int ros_DebugSocket = -1;
 struct sockaddr_in ros_debug_destAddr1;

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -393,11 +393,11 @@ void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup)
                 JointMotionData* startTrajData;
                 JointMotionData* endTrajData;
                 JointMotionData* curTrajData;
-                double interval;					// Time between startTime and the new data time
+                double interval;                    // Time between startTime and the new data time
                 double accCoef1[MP_GRP_AXES_NUM];   // Acceleration coefficient 1
                 double accCoef2[MP_GRP_AXES_NUM];   // Acceleration coefficient 2
-                UINT64 timeInc_ms;					// time increment in millisecond
-                UINT64 calculationTime_ms;			// time in ms at which the interpolation takes place
+                UINT64 timeInc_ms;                  // time increment in millisecond
+                UINT64 calculationTime_ms;          // time in ms at which the interpolation takes place
                 long newPulsePos[MP_GRP_AXES_NUM];
                 Incremental_data incData;
 
@@ -475,15 +475,15 @@ void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup)
                         for (i = 0; i < ctrlGroup->numAxes; i++)
                         {
                             // Add position change for new interpolation time
-                            curTrajData->pos[i] = startTrajData->pos[i] 						// initial position component
-                                + startTrajData->vel[i] * interpolTime  						// initial velocity component
-                                + accCoef1[i] * interpolTime * interpolTime / 2 				// accCoef1 component
-                                + accCoef2[i] * interpolTime * interpolTime * interpolTime / 6;	// accCoef2 component
+                            curTrajData->pos[i] = startTrajData->pos[i]                         // initial position component
+                                + startTrajData->vel[i] * interpolTime                          // initial velocity component
+                                + accCoef1[i] * interpolTime * interpolTime / 2                 // accCoef1 component
+                                + accCoef2[i] * interpolTime * interpolTime * interpolTime / 6; // accCoef2 component
 
                             // Add velocity change for new interpolation time
-                            curTrajData->vel[i] = startTrajData->vel[i]   						// initial velocity component
-                                + accCoef1[i] * interpolTime 									// accCoef1 component
-                                + accCoef2[i] * interpolTime * interpolTime / 2;				// accCoef2 component
+                            curTrajData->vel[i] = startTrajData->vel[i]                         // initial velocity component
+                                + accCoef1[i] * interpolTime                                    // accCoef1 component
+                                + accCoef2[i] * interpolTime * interpolTime / 2;                // accCoef2 component
                         }
 
                         // Reset the timeInc_ms for the next interpolation cycle

--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -8,18 +8,18 @@
 #ifndef MOTOROS2_MOTION_CONTROL_H
 #define MOTOROS2_MOTION_CONTROL_H
 
-#define START_MAX_PULSE_DEVIATION			30
+#define START_MAX_PULSE_DEVIATION           30
 
-#define MOTION_START_TIMEOUT				5000  // in milliseconds
-#define MOTION_START_CHECK_PERIOD			50  // in millisecond
-#define MOTION_STOP_TIMEOUT					20
+#define MOTION_START_TIMEOUT                5000  // in milliseconds
+#define MOTION_START_CHECK_PERIOD           50  // in millisecond
+#define MOTION_STOP_TIMEOUT                 20
 
 #ifndef E_EXRCS_PFL_FUNC_BUSY
-#define E_EXRCS_PFL_FUNC_BUSY				(-19)
+#define E_EXRCS_PFL_FUNC_BUSY               (-19)
 #endif
 
 #ifndef E_EXRCS_UNDER_ENERGY_SAVING
-#define E_EXRCS_UNDER_ENERGY_SAVING			(-20)
+#define E_EXRCS_UNDER_ENERGY_SAVING         (-20)
 #endif
 
 typedef enum

--- a/src/MotoPlusExterns.h
+++ b/src/MotoPlusExterns.h
@@ -12,8 +12,8 @@
 #define MP_MEM_PART_SIZE 1048576
 
 extern int mpNICData(USHORT if_no, ULONG* ip_addr, ULONG* subnet_mask, UCHAR* mac_addr, ULONG* default_gw);
-#define	MP_USER_LAN1		1	/* general LAN interface1 */
-#define	MP_USER_LAN2		2	/* general LAN interface2(only YRC1000) */
+#define MP_USER_LAN1 1 /* general LAN interface1 */
+#define MP_USER_LAN2 2 /* general LAN interface2(only YRC1000) */
 
 extern size_t mpNumBytesFree(void);
 

--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -105,7 +105,7 @@
 
 extern void Ros_Sleep(float milliseconds);
 
-#define max(x, y)	(((x) < (y)) ? (y) : (x))
-#define min(x, y)	(((x) < (y)) ? (x) : (y))
+#define max(x, y)   (((x) < (y)) ? (y) : (x))
+#define min(x, y)   (((x) < (y)) ? (x) : (y))
 
 #endif  // MOTOROS2_MOTOROS_H

--- a/src/PositionMonitor.c
+++ b/src/PositionMonitor.c
@@ -358,9 +358,9 @@ void Ros_PositionMonitor_CalculateTransforms(int groupIndex, long* pulsePos_moto
     mpMulFrame(&frameBaseToTcp, &frameTcpToTool0, &frameBaseToTool0);
 
     //Make rotational frames
-    vectorOrg.x = 0;	vectorOrg.y = 0;	vectorOrg.z = 0;
-    vectorX.x = 0;		vectorX.y = 0;		vectorX.z = 1;
-    vectorY.x = 0;		vectorY.y = -1;		vectorY.z = 0;
+    vectorOrg.x = 0;    vectorOrg.y = 0;    vectorOrg.z = 0;
+    vectorX.x = 0;      vectorX.y = 0;      vectorX.z = 1;
+    vectorY.x = 0;      vectorY.y = -1;     vectorY.z = 0;
     mpMakeFrame(&vectorOrg, &vectorX, &vectorY, &frameTool0ToFlange);
     mpInvFrame(&frameTool0ToFlange, &frameFlangeToTool0);
     mpFrameToZYXeuler(&frameFlangeToTool0, &coordFlangeToTool0);

--- a/src/Quaternion_Conversion.c
+++ b/src/Quaternion_Conversion.c
@@ -75,11 +75,11 @@
 #include "MotoROS.h"
 
 #ifndef max
-#define max(x, y)	(((x) < (y)) ? (y) : (x))
+#define max(x, y)   (((x) < (y)) ? (y) : (x))
 #endif
 
 #ifndef min
-#define min(x, y)	(((x) < (y)) ? (x) : (y))
+#define min(x, y)   (((x) < (y)) ? (x) : (y))
 #endif
 
 double QuatConversion_clamp(double value, double _min, double _max)

--- a/src/ServiceReadWriteIO.c
+++ b/src/ServiceReadWriteIO.c
@@ -244,8 +244,8 @@ static const char* const Ros_IoServer_ResultCodeToStr(UINT32 resultCode);
 //* end of controller IO range defs ************************
 #endif
 
-#define QUANTITY_BIT	(1)
-#define QUANTITY_BYTE	(8)
+#define QUANTITY_BIT    (1)
+#define QUANTITY_BYTE   (8)
 
 rcl_service_t g_serviceReadSingleIO;
 rcl_service_t g_serviceReadGroupIO;


### PR DESCRIPTION
As per subject.

It's a sad day, but this would see the last of the tabs be replaced by spaces in MotoROS2 `.h`s and `.c`s (well, in files where it makes sense).

Our `.editorconfig` already forced supporting editors to use spaces, but it didn't replace the ones that were already there.

No functional changes.
