### PR TITLE
Remove unneeded `mpNICData(..)` extern

### DIFF
--- a/src/MotoPlusExterns.h
+++ b/src/MotoPlusExterns.h
@@ -11,10 +11,6 @@
 
 #define MP_MEM_PART_SIZE 1048576
 
-extern int mpNICData(USHORT if_no, ULONG* ip_addr, ULONG* subnet_mask, UCHAR* mac_addr, ULONG* default_gw);
-#define MP_USER_LAN1 1 /* general LAN interface1 */
-#define MP_USER_LAN2 2 /* general LAN interface2(only YRC1000) */
-
 extern size_t mpNumBytesFree(void);
 
 extern MP_GRP_ID_TYPE mpCtrlGrpNo2GrpId(int grp_no);


### PR DESCRIPTION
As per subject.

Part of `MotoROS_PlatformLib` since 'v0.2.0'.
