### PR TITLE
Address a couple of linting (`cppcheck`) issues

### DIFF
--- a/src/CommunicationExecutor.c
+++ b/src/CommunicationExecutor.c
@@ -160,7 +160,7 @@ void Ros_Communication_Initialize()
     motoRosAssert(ret == RCL_RET_OK, SUBCODE_FAIL_NODE_INIT);
 
     //we're done with it
-    ret = rcl_node_options_fini(&node_options);
+    ret = rcl_node_options_fini(&node_options); RCL_UNUSED(ret);
     Ros_CleanupFauxArgv(faux_argv, faux_argc);
 
     MOTOROS2_MEM_TRACE_REPORT(comm_exec_init);

--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -221,7 +221,6 @@ void Ros_ConfigFile_CheckYamlEvent(yaml_event_t* event)
 
     char* t[] = { "y", "Y", "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON", "1", NULL };
     char* f[] = { "n", "N", "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF", "0", NULL };
-    BOOL bBoolValueFound;
 
     if (event->type == YAML_SCALAR_EVENT)
     {
@@ -229,6 +228,8 @@ void Ros_ConfigFile_CheckYamlEvent(yaml_event_t* event)
         {
             if (event->data.scalar.length > 0)
             {
+                BOOL bBoolValueFound = FALSE;
+
                 switch (activeItem->typeOfValue)
                 {
                 case Value_String:

--- a/src/ControllerStatusIO.c
+++ b/src/ControllerStatusIO.c
@@ -650,8 +650,8 @@ BOOL Ros_Controller_IoStatusUpdate()
                 g_messages_RobotStatus.msgRobotStatus->error_codes.size = num_alarms;
                 // 'msgRobotStatus->error_codes' has been initialised to be of
                 // length 'MAX_ALARM_COUNT + 1' in Ros_Controller_Initialize()
-                for (int i = 0; i < num_alarms; ++i)
-                    g_messages_RobotStatus.msgRobotStatus->error_codes.data[i] = active_alarms[i];
+                for (int alm = 0; alm < num_alarms; ++alm)
+                    g_messages_RobotStatus.msgRobotStatus->error_codes.data[alm] = active_alarms[alm];
             }
         }
 

--- a/src/InformCheckerAndGenerator.c
+++ b/src/InformCheckerAndGenerator.c
@@ -213,9 +213,9 @@ BOOL Ros_InformChecker_CheckHeaderForGroupCombinations(int fdJob)
     for (int groupIndex = 0; groupIndex < g_Ros_Controller.numGroup; groupIndex += 1)
     {
         CtrlGroup* group = g_Ros_Controller.ctrlGroups[groupIndex];
-        BOOL bGroupFound = FALSE;
         if (group)
         {
+            BOOL bGroupFound = FALSE;
             //iterate over the used groups
             for (int i = 0; i < MAX_GROUP_COMBINATIONS; i += 1)
             {

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -627,7 +627,6 @@ UINT8 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__Q
     //------------------------------------------------------------
     //The trajectory contains information for all groups. Determine which groups are used by looking at the 'joint names'.
     int grpIndex, jointIndexInTraj;
-    CtrlGroup* ctrlGroup;
 
     if (g_Ros_Controller.totalAxesCount != request->joint_names.size)
     {
@@ -644,7 +643,7 @@ UINT8 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__Q
     //precheck to ensure all groups are ready to accept a new point
     for (grpIndex = 0; grpIndex < g_Ros_Controller.numGroup; grpIndex += 1)
     {
-        ctrlGroup = g_Ros_Controller.ctrlGroups[grpIndex];
+        CtrlGroup* ctrlGroup = g_Ros_Controller.ctrlGroups[grpIndex];
 
         if (ctrlGroup->trajectoryIterator != NULL && ctrlGroup->trajectoryIterator->valid)
         {
@@ -726,7 +725,7 @@ UINT8 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__Q
 
     for (grpIndex = 0; grpIndex < g_Ros_Controller.numGroup; grpIndex += 1)
     {
-        ctrlGroup = g_Ros_Controller.ctrlGroups[grpIndex];
+        CtrlGroup* ctrlGroup = g_Ros_Controller.ctrlGroups[grpIndex];
 
         ctrlGroup->trajectoryIterator->valid = TRUE;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -135,20 +135,20 @@ void RosInitTask()
                        mpNumBytesFree(), MP_MEM_PART_SIZE - mpNumBytesFree());
 
         //==================================
-        ULONG tickNow = 0, tickBefore = 0, tickDiff;
-        float elapsedMs = 0;
+        ULONG tickBefore = 0;
 
         while(g_Ros_Communication_AgentIsConnected)
         {
             //figure out how long to sleep to achieve the user-configured rate
-            tickNow = tickGet();
-            
+            ULONG tickNow = tickGet();
+
+            ULONG tickDiff = 0;
             if (tickNow > tickBefore)
                 tickDiff = tickNow - tickBefore;
             else //unsigned rollover
                 tickDiff = (UINT_MAX - tickBefore) + tickNow;
 
-            elapsedMs = tickDiff * mpGetRtc(); //time it took to read and publish data
+            float elapsedMs = tickDiff * mpGetRtc(); //time it took to read and publish data
 
             if (elapsedMs < g_nodeConfigSettings.controller_status_monitor_period)
                 Ros_Sleep(g_nodeConfigSettings.controller_status_monitor_period - elapsedMs);


### PR DESCRIPTION
As per subject.

`cppcheck` complained about these.

This still doesn't get us to a 100% warning/error free linting run, but the remaining issues are minor (there's one left in `CtrlGroup.c` where we append to a `char[]` using `sprintf(..)`).
