### PR TITLE
ci: only run msbuild if needed

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -11,8 +11,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  msbuild_filter:
+    runs-on: ubuntu-latest
+    outputs:
+      needs_msbuild: ${{ steps.paths_filter.outputs.vsproj }}
+    steps:
+      - name: Checkout MotoROS2
+        uses: actions/checkout@v3
+      - name: Check VS proj has changed
+        id: paths_filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            vsproj:
+              - 'src/**'
+              - 'MotoROS2.sln'
+
   msbuild:
     runs-on: windows-2022
+    needs: msbuild_filter
+    if: needs.msbuild_filter.outputs.needs_msbuild == 'true'
 
     strategy:
       # keep jobs running even if one fails (we want to know on which


### PR DESCRIPTION
As per subject.

See the commit comment for rationale.

Summarising: this only starts the (full) build of MotoROS2 if a PR actually changes files that would be part of such builds. No point in starting 6 builds if only one `.md` file (ie: documentation) was changed.
