### PR TITLE
ci: no MSBuild CI unless source repo == main repo

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -30,7 +30,11 @@ jobs:
   msbuild:
     runs-on: windows-2022
     needs: msbuild_filter
-    if: needs.msbuild_filter.outputs.needs_msbuild == 'true'
+    # only run this job if source files were changed,
+    # AND the PR came from a feature branch on the main repository
+    if: |
+      needs.msbuild_filter.outputs.needs_msbuild == 'true' &&
+        github.event.pull_request.head.repo.full_name == github.repository
 
     strategy:
       # keep jobs running even if one fails (we want to know on which


### PR DESCRIPTION
As per subject.

This is a work-around as we can't let PRs from forks access secrets securely.

Loosely based on [Workflow syntax for GitHub Actions: Example: Only run job for specific repository](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository).
