### PR TITLE
Fixed Cryptic Error Codes in mpStartJob

### DIFF
--- a/src/ErrorHandling.c
+++ b/src/ErrorHandling.c
@@ -15,6 +15,8 @@ const char* const Ros_ErrorHandling_ErrNo_ToString(int errNo)
 {
     switch (errNo)
     {
+    //Note: returning literals here as 'const char*' is OK, as they are stored
+    //in an anonymous array with static storage.
     case 0x2010: return "Robot is in operation";
     case 0x2030: return "In HOLD status (PP)";
     case 0x2040: return "In HOLD status (External)";

--- a/src/ErrorHandling.c
+++ b/src/ErrorHandling.c
@@ -32,41 +32,6 @@ const char* const Ros_ErrorHandling_ErrNo_ToString(int errNo)
     }
 }
 
-const char* const Ros_ErrorHandling_Only_ErrNo_ToString(int errNo)
-{
-    switch (errNo)
-    {
-    case 0x2010:
-        return "Robot is in operation";
-    case 0x2030:
-        return "In HOLD status (PP)";
-    case 0x2040:
-        return "In HOLD status (External)";
-    case 0x2050:
-        return "In HOLD status (Command)";
-    case 0x2060:
-        return "In ERROR/ALARM status";
-    case 0x2070:
-        return "In SERVO OFF status";
-    case 0x2080:
-        return "Wrong operation mode";
-    case 0x3040:
-        return "The home position is not registered";
-    case 0x3050:
-        return "Out of range (ABSO data)";
-    case 0x3400:
-        return "Cannot operate MASTER JOB";
-    case 0x3410:
-        return "The JOB name is already registered in another task";
-    case 0x4040:
-        return "Specified JOB not found";
-    case 0x5200:
-        return "Over data range";
-    default:
-        return "Unspecified reason";
-    }
-}
-
 const char* const Ros_ErrorHandling_MotionNotReadyCode_ToString(MotionNotReadyCode code)
 {
     //messages defined in motoros2_interfaces/msg/MotionReadyEnum.msg

--- a/src/ErrorHandling.c
+++ b/src/ErrorHandling.c
@@ -11,24 +11,24 @@
 //-------------------------------------------------------------------
 // Convert error code to string
 //-------------------------------------------------------------------
-void Ros_ErrorHandling_ErrNo_ToString(int errNo, char* const errMsg, int errMsgSize)
+const char* const Ros_ErrorHandling_ErrNo_ToString(int errNo)
 {
     switch (errNo)
     {
-    case 0x2010: strncpy(errMsg, "Robot is in operation", errMsgSize); break;
-    case 0x2030: strncpy(errMsg, "In HOLD status (PP)", errMsgSize); break;
-    case 0x2040: strncpy(errMsg, "In HOLD status (External)", errMsgSize); break;
-    case 0x2050: strncpy(errMsg, "In HOLD status (Command)", errMsgSize); break;
-    case 0x2060: strncpy(errMsg, "In ERROR/ALARM status", errMsgSize); break;
-    case 0x2070: strncpy(errMsg, "In SERVO OFF status", errMsgSize); break;
-    case 0x2080: strncpy(errMsg, "Wrong operation mode", errMsgSize); break;
-    case 0x3040: strncpy(errMsg, "The home position is not registered", errMsgSize); break;
-    case 0x3050: strncpy(errMsg, "Out of range (ABSO data)", errMsgSize); break;
-    case 0x3400: strncpy(errMsg, "Cannot operate MASTER JOB", errMsgSize); break;
-    case 0x3410: strncpy(errMsg, "The JOB name is already registered in another task", errMsgSize); break;
-    case 0x4040: strncpy(errMsg, "Specified JOB not found", errMsgSize); break;
-    case 0x5200: strncpy(errMsg, "Over data range", errMsgSize); break;
-    default: strncpy(errMsg, "Unspecified reason", errMsgSize); break;
+    case 0x2010: return "Robot is in operation";
+    case 0x2030: return "In HOLD status (PP)";
+    case 0x2040: return "In HOLD status (External)";
+    case 0x2050: return "In HOLD status (Command)";
+    case 0x2060: return "In ERROR/ALARM status";
+    case 0x2070: return "In SERVO OFF status";
+    case 0x2080: return "Wrong operation mode";
+    case 0x3040: return "The home position is not registered";
+    case 0x3050: return "Out of range (ABSO data)";
+    case 0x3400: return "Cannot operate MASTER JOB";
+    case 0x3410: return "The JOB name is already registered in another task";
+    case 0x4040: return "Specified JOB not found";
+    case 0x5200: return "Over data range";
+    default:     return "Unspecified reason";
     }
 }
 

--- a/src/ErrorHandling.c
+++ b/src/ErrorHandling.c
@@ -32,6 +32,41 @@ void Ros_ErrorHandling_ErrNo_ToString(int errNo, char* const errMsg, int errMsgS
     }
 }
 
+const char* const Ros_ErrorHandling_Only_ErrNo_ToString(int errNo)
+{
+    switch (errNo)
+    {
+    case 0x2010:
+        return "Robot is in operation";
+    case 0x2030:
+        return "In HOLD status (PP)";
+    case 0x2040:
+        return "In HOLD status (External)";
+    case 0x2050:
+        return "In HOLD status (Command)";
+    case 0x2060:
+        return "In ERROR/ALARM status";
+    case 0x2070:
+        return "In SERVO OFF status";
+    case 0x2080:
+        return "Wrong operation mode";
+    case 0x3040:
+        return "The home position is not registered";
+    case 0x3050:
+        return "Out of range (ABSO data)";
+    case 0x3400:
+        return "Cannot operate MASTER JOB";
+    case 0x3410:
+        return "The JOB name is already registered in another task";
+    case 0x4040:
+        return "Specified JOB not found";
+    case 0x5200:
+        return "Over data range";
+    default:
+        return "Unspecified reason";
+    }
+}
+
 const char* const Ros_ErrorHandling_MotionNotReadyCode_ToString(MotionNotReadyCode code)
 {
     //messages defined in motoros2_interfaces/msg/MotionReadyEnum.msg

--- a/src/ErrorHandling.h
+++ b/src/ErrorHandling.h
@@ -206,6 +206,7 @@ extern void motoRosAssert(BOOL mustBeTrue, ASSERTION_SUBCODE subCodeIfFalse);
 extern void motoRosAssert_withMsg(BOOL mustBeTrue, ASSERTION_SUBCODE subCodeIfFalse, char* msgFmtIfFalse, ...);
 
 extern void Ros_ErrorHandling_ErrNo_ToString(int errNo, char* const errMsg, int errMsgSize);
+extern const char* const Ros_ErrorHandling_Only_ErrNo_ToString(int errNo);
 extern const char* const Ros_ErrorHandling_MotionNotReadyCode_ToString(MotionNotReadyCode code);
 
 #endif  // MOTOROS2_ERROR_HANDLING_H

--- a/src/ErrorHandling.h
+++ b/src/ErrorHandling.h
@@ -205,7 +205,7 @@ typedef enum
 extern void motoRosAssert(BOOL mustBeTrue, ASSERTION_SUBCODE subCodeIfFalse);
 extern void motoRosAssert_withMsg(BOOL mustBeTrue, ASSERTION_SUBCODE subCodeIfFalse, char* msgFmtIfFalse, ...);
 
-extern void Ros_ErrorHandling_ErrNo_ToString(int errNo, char* const errMsg, int errMsgSize);
+extern const char* const Ros_ErrorHandling_ErrNo_ToString(int errNo);
 extern const char* const Ros_ErrorHandling_Only_ErrNo_ToString(int errNo);
 extern const char* const Ros_ErrorHandling_MotionNotReadyCode_ToString(MotionNotReadyCode code);
 

--- a/src/ErrorHandling.h
+++ b/src/ErrorHandling.h
@@ -206,7 +206,6 @@ extern void motoRosAssert(BOOL mustBeTrue, ASSERTION_SUBCODE subCodeIfFalse);
 extern void motoRosAssert_withMsg(BOOL mustBeTrue, ASSERTION_SUBCODE subCodeIfFalse, char* msgFmtIfFalse, ...);
 
 extern const char* const Ros_ErrorHandling_ErrNo_ToString(int errNo);
-extern const char* const Ros_ErrorHandling_Only_ErrNo_ToString(int errNo);
 extern const char* const Ros_ErrorHandling_MotionNotReadyCode_ToString(MotionNotReadyCode code);
 
 #endif  // MOTOROS2_ERROR_HANDLING_H

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1287,7 +1287,8 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
     {
         //TODO(gavanderhoorn): special check for "job is not loaded"
         Ros_Debug_BroadcastMsg(
-            "Can't start '%s' because: 0x%04X %s", g_nodeConfigSettings.inform_job_name, rData.err_no, Ros_ErrorHandling_Only_ErrNo_ToString(rData.err_no));
+            "Can't start '%s' because: 0x%04X %s", g_nodeConfigSettings.inform_job_name, rData.err_no,
+            Ros_ErrorHandling_ErrNo_ToString(rData.err_no));
         goto updateStatus;
     }
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1252,7 +1252,9 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
         {
             //TODO(gavanderhoorn): should this be reported to user, or are causes
             //covered by errors in MotionNotReadyCode?
-            Ros_Debug_BroadcastMsg("Can't turn on servo because: 0x%04X", rData.err_no);
+            Ros_Debug_BroadcastMsg(
+                "Can't turn on servo because: '%s' (0x%04X)",
+                Ros_ErrorHandling_ErrNo_ToString(rData.err_no), rData.err_no);
             goto updateStatus;
         }
     }

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1289,8 +1289,8 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
     {
         //TODO(gavanderhoorn): special check for "job is not loaded"
         Ros_Debug_BroadcastMsg(
-            "Can't start '%s' because: 0x%04X %s", g_nodeConfigSettings.inform_job_name, rData.err_no,
-            Ros_ErrorHandling_ErrNo_ToString(rData.err_no));
+            "Can't start '%s' because: '%s' (0x%04X)", g_nodeConfigSettings.inform_job_name,
+            Ros_ErrorHandling_ErrNo_ToString(rData.err_no), rData.err_no);
         goto updateStatus;
     }
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1287,7 +1287,7 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
     {
         //TODO(gavanderhoorn): special check for "job is not loaded"
         Ros_Debug_BroadcastMsg(
-            "Can't start '%s' because: 0x%04X", g_nodeConfigSettings.inform_job_name, rData.err_no);
+            "Can't start '%s' because: 0x%04X %s", g_nodeConfigSettings.inform_job_name, rData.err_no, Ros_ErrorHandling_Only_ErrNo_ToString(rData.err_no));
         goto updateStatus;
     }
 


### PR DESCRIPTION
fixes #102. I wrote a new function that kept the error string format as an f-string for mpStartJob errors in MotionControl.c by just adding a new function called Ros_ErrorHandling_Only_ErrNo_ToString in ErrorHandling.c that did not use strncpy and therefore did not need a buffer to get passed in, similar to Ros_ErrorHandling_MotionNotReadyCode_ToString it just returns a char* instead of having a destination for the chars and can be directly passed into the error f-string.