### PR TITLE
Remove duplicated `min(..)` & `max(..)` macros

### DIFF
--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -106,7 +106,4 @@
 
 extern void Ros_Sleep(float milliseconds);
 
-#define max(x, y)   (((x) < (y)) ? (y) : (x))
-#define min(x, y)   (((x) < (y)) ? (x) : (y))
-
 #endif  // MOTOROS2_MOTOROS_H


### PR DESCRIPTION
As per subject.

The are already provided by `motoPlus.h` in the M+ SDK.
