### PR TITLE
Include ROS 2 version in `AppInfo` on controller

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -40,11 +40,12 @@ void Ros_ReportVersionInfoToController()
     MP_APPINFO_SEND_DATA appInfoSendData;
     MP_STD_RSP_DATA stdResponseData;
 
-    sprintf(appInfoSendData.AppName, "%s (%s)",
-        APPLICATION_NAME, MOTOPLUS_LIBMICROROS_ROS2_CODENAME);
-    sprintf(appInfoSendData.Version, "%s", APPLICATION_VERSION);
-    sprintf(appInfoSendData.Comment, "%s", "micro-ROS based ROS 2 interface");
-
+    snprintf(appInfoSendData.AppName, MP_MAX_APP_NAME,
+        "%s (%s)", APPLICATION_NAME, MOTOPLUS_LIBMICROROS_ROS2_CODENAME);
+    snprintf(appInfoSendData.Version, MP_MAX_APP_VERSION,
+        "%s", APPLICATION_VERSION);
+    snprintf(appInfoSendData.Comment, MP_MAX_APP_COMMENT,
+        "%s", "micro-ROS based ROS 2 interface");
     mpApplicationInfoNotify(&appInfoSendData, &stdResponseData); //don't care about return value
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -40,10 +40,10 @@ void Ros_ReportVersionInfoToController()
     MP_APPINFO_SEND_DATA appInfoSendData;
     MP_STD_RSP_DATA stdResponseData;
 
-    sprintf(appInfoSendData.AppName, APPLICATION_NAME);
-
+    sprintf(appInfoSendData.AppName, "%s (%s)",
+        APPLICATION_NAME, MOTOPLUS_LIBMICROROS_ROS2_CODENAME);
     sprintf(appInfoSendData.Version, "%s", APPLICATION_VERSION);
-    sprintf(appInfoSendData.Comment, "micro-ROS based ROS 2 interface");
+    sprintf(appInfoSendData.Comment, "%s", "micro-ROS based ROS 2 interface");
 
     mpApplicationInfoNotify(&appInfoSendData, &stdResponseData); //don't care about return value
 }


### PR DESCRIPTION
I noticed we actually don't have any way of determining _which_ ROS 2 version is supported by which MR2 binary, other than asking the user.

Now that #109 is merged, it's possible to derive this information from the name of the `.out`, but that's not very convenient.

This PR changes the way MotoROS2 registers itself with the "application information" infrastructure to add the ROS 2 codename to the version nr/string.

It changes the line in the `PANELBOX.LOG` from :

```
//MOTOPLUS APP
01: MotoROS2                         0.1.0            micro-ROS based ROS 2 interface 
```

to:

```
//MOTOPLUS APP
01: MotoROS2 (humble)                0.1.0            micro-ROS based ROS 2 interface 
```

From this, it's clear MotoROS2 version `0.1.0` supporting ROS 2 Humble is installed on this controller.
