### PR TITLE
Dump complete cfg after parsing it

### DIFF
--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -740,13 +740,13 @@ void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* c
     }
     Ros_Debug_BroadcastMsg("---");
 
-    Ros_Debug_BroadcastMsg("Config: log_to_stdout = %d", config->log_to_stdout);
-    Ros_Debug_BroadcastMsg("Config: executor_sleep_period = %d", config->executor_sleep_period);
-    Ros_Debug_BroadcastMsg("Config: action_feedback_publisher_period = %d", config->action_feedback_publisher_period);
-    Ros_Debug_BroadcastMsg("Config: controller_status_monitor_period = %d", config->controller_status_monitor_period);
-    Ros_Debug_BroadcastMsg("Config: robot_status = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_robot_status));
-    Ros_Debug_BroadcastMsg("Config: joint_states = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_joint_states));
-    Ros_Debug_BroadcastMsg("Config: tf = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_tf));
+    Ros_Debug_BroadcastMsg("Config: logging.log_to_stdout = %d", config->log_to_stdout);
+    Ros_Debug_BroadcastMsg("Config: update_periods.executor_sleep_period = %d", config->executor_sleep_period);
+    Ros_Debug_BroadcastMsg("Config: update_periods.action_feedback_publisher_period = %d", config->action_feedback_publisher_period);
+    Ros_Debug_BroadcastMsg("Config: update_periods.controller_status_monitor_period = %d", config->controller_status_monitor_period);
+    Ros_Debug_BroadcastMsg("Config: publisher_qos.robot_status = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_robot_status));
+    Ros_Debug_BroadcastMsg("Config: publisher_qos.joint_states = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_joint_states));
+    Ros_Debug_BroadcastMsg("Config: publisher_qos.tf = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_tf));
     Ros_Debug_BroadcastMsg("Config: tf_frame_prefix = %s", config->tf_frame_prefix);
     Ros_Debug_BroadcastMsg("Config: stop_motion_on_disconnect = %d", config->stop_motion_on_disconnect);
     Ros_Debug_BroadcastMsg("Config: inform_job_name = %s", config->inform_job_name);

--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -697,6 +697,47 @@ void Ros_ConfigFile_ValidateNonCriticalSettings()
     }
 }
 
+void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* const config)
+{
+    Ros_Debug_BroadcastMsg("Config: ros_domain_id = %d", config->ros_domain_id);
+    Ros_Debug_BroadcastMsg("Config: node_name = %s", config->node_name);
+    Ros_Debug_BroadcastMsg("Config: node_namespace = %s", config->node_namespace);
+    Ros_Debug_BroadcastMsg("Config: remap_rules = %s", config->remap_rules);
+    Ros_Debug_BroadcastMsg("Config: agent_ip_address = %s", config->agent_ip_address);
+    Ros_Debug_BroadcastMsg("Config: agent_port_number = %s", config->agent_port_number);
+    Ros_Debug_BroadcastMsg("Config: sync_timeclock_with_agent = %d", config->sync_timeclock_with_agent);
+    Ros_Debug_BroadcastMsg("Config: namespace_tf = %d", config->namespace_tf);
+    Ros_Debug_BroadcastMsg("Config: publish_tf = %d", config->publish_tf);
+    Ros_Debug_BroadcastMsg("List of configured joint names:");
+
+    for (int i = 0; i < MAX_CONTROLLABLE_GROUPS; i += 1)
+    {
+        Ros_Debug_BroadcastMsg("---");
+        for (int j = 0; j < MP_GRP_AXES_NUM; j += 1)
+        {
+            if (strlen(config->joint_names[(i * MP_GRP_AXES_NUM) + j]) > 0)
+                Ros_Debug_BroadcastMsg(config->joint_names[(i * MP_GRP_AXES_NUM) + j]);
+            else
+                Ros_Debug_BroadcastMsg("x");
+        }
+    }
+    Ros_Debug_BroadcastMsg("---");
+
+    Ros_Debug_BroadcastMsg("Config: log_to_stdout = %d", config->log_to_stdout);
+    Ros_Debug_BroadcastMsg("Config: executor_sleep_period = %d", config->executor_sleep_period);
+    Ros_Debug_BroadcastMsg("Config: action_feedback_publisher_period = %d", config->action_feedback_publisher_period);
+    Ros_Debug_BroadcastMsg("Config: controller_status_monitor_period = %d", config->controller_status_monitor_period);
+    Ros_Debug_BroadcastMsg("Config: robot_status = %d", config->qos_robot_status);
+    Ros_Debug_BroadcastMsg("Config: joint_states = %d", config->qos_joint_states);
+    Ros_Debug_BroadcastMsg("Config: tf = %d", config->qos_tf);
+    Ros_Debug_BroadcastMsg("Config: tf_frame_prefix = %s", config->tf_frame_prefix);
+    Ros_Debug_BroadcastMsg("Config: stop_motion_on_disconnect = %d", config->stop_motion_on_disconnect);
+    Ros_Debug_BroadcastMsg("Config: inform_job_name = %s", config->inform_job_name);
+    Ros_Debug_BroadcastMsg("Config: allow_custom_inform_job = %d", config->allow_custom_inform_job);
+    Ros_Debug_BroadcastMsg("Config: userlan_monitor_enabled = %d", config->userlan_monitor_enabled);
+    Ros_Debug_BroadcastMsg("Config: userlan_monitor_port = %d", config->userlan_monitor_port);
+}
+
 void Ros_ConfigFile_Parse()
 {
     BOOL bAlarmOnce = TRUE;
@@ -799,42 +840,7 @@ void Ros_ConfigFile_Parse()
 
     Ros_ConfigFile_ValidateCriticalSettings();
     Ros_ConfigFile_ValidateNonCriticalSettings();
-
-    Ros_Debug_BroadcastMsg("Config: ros_domain_id = %d", g_nodeConfigSettings.ros_domain_id);
-    Ros_Debug_BroadcastMsg("Config: node_name = %s", g_nodeConfigSettings.node_name);
-    Ros_Debug_BroadcastMsg("Config: node_namespace = %s", g_nodeConfigSettings.node_namespace);
-    Ros_Debug_BroadcastMsg("Config: remap_rules = %s", g_nodeConfigSettings.remap_rules);
-    Ros_Debug_BroadcastMsg("Config: agent_ip_address = %s", g_nodeConfigSettings.agent_ip_address);
-    Ros_Debug_BroadcastMsg("Config: agent_port_number = %s", g_nodeConfigSettings.agent_port_number);
-    Ros_Debug_BroadcastMsg("Config: sync_timeclock_with_agent = %d", g_nodeConfigSettings.sync_timeclock_with_agent);
-    Ros_Debug_BroadcastMsg("Config: namespace_tf = %d", g_nodeConfigSettings.namespace_tf);
-    Ros_Debug_BroadcastMsg("Config: publish_tf = %d", g_nodeConfigSettings.publish_tf);
-    Ros_Debug_BroadcastMsg("List of configured joint names:");
-    for (int i = 0; i < MAX_CONTROLLABLE_GROUPS; i += 1)
-    {
-        Ros_Debug_BroadcastMsg("---");
-        for (int j = 0; j < MP_GRP_AXES_NUM; j += 1)
-        {
-            if (strlen(g_nodeConfigSettings.joint_names[(i * MP_GRP_AXES_NUM) + j]) > 0)
-                Ros_Debug_BroadcastMsg(g_nodeConfigSettings.joint_names[(i * MP_GRP_AXES_NUM) + j]);
-            else
-                Ros_Debug_BroadcastMsg("x");
-        }
-    }
-    Ros_Debug_BroadcastMsg("---");
-    Ros_Debug_BroadcastMsg("Config: log_to_stdout = %d", g_nodeConfigSettings.log_to_stdout);
-    Ros_Debug_BroadcastMsg("Config: executor_sleep_period = %d", g_nodeConfigSettings.executor_sleep_period);
-    Ros_Debug_BroadcastMsg("Config: action_feedback_publisher_period = %d", g_nodeConfigSettings.action_feedback_publisher_period);
-    Ros_Debug_BroadcastMsg("Config: controller_status_monitor_period = %d", g_nodeConfigSettings.controller_status_monitor_period);
-    Ros_Debug_BroadcastMsg("Config: robot_status = %d", g_nodeConfigSettings.qos_robot_status);
-    Ros_Debug_BroadcastMsg("Config: joint_states = %d", g_nodeConfigSettings.qos_joint_states);
-    Ros_Debug_BroadcastMsg("Config: tf = %d", g_nodeConfigSettings.qos_tf);
-    Ros_Debug_BroadcastMsg("Config: tf_frame_prefix = %s", g_nodeConfigSettings.tf_frame_prefix);
-    Ros_Debug_BroadcastMsg("Config: stop_motion_on_disconnect = %d", g_nodeConfigSettings.stop_motion_on_disconnect);
-    Ros_Debug_BroadcastMsg("Config: inform_job_name = %s", g_nodeConfigSettings.inform_job_name);
-    Ros_Debug_BroadcastMsg("Config: allow_custom_inform_job = %d", g_nodeConfigSettings.allow_custom_inform_job);
-    Ros_Debug_BroadcastMsg("Config: userlan_monitor_enabled = %d", g_nodeConfigSettings.userlan_monitor_enabled);
-    Ros_Debug_BroadcastMsg("Config: userlan_monitor_port = %d", g_nodeConfigSettings.userlan_monitor_port);    
+    Ros_ConfigFile_PrintActiveConfiguration(&g_nodeConfigSettings);
 }
 
 rmw_qos_profile_t const* const Ros_ConfigFile_To_Rmw_Qos_Profile(Ros_QoS_Profile_Setting val)

--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -303,9 +303,9 @@ void Ros_ConfigFile_CheckYamlEvent(yaml_event_t* event)
                     break;
 
                 case Value_Qos:
-                    if (strcmp((char*)event->data.scalar.value, "sensor_data") == 0)
+                    if (strcmp((char*)event->data.scalar.value, ROS_QOS_PROFILE_SENSOR_DATA_NAME) == 0)
                         *(Ros_QoS_Profile_Setting*)activeItem->valueToSet = ROS_QOS_PROFILE_SENSOR_DATA;
-                    else if (strcmp((char*)event->data.scalar.value, "default") == 0)
+                    else if (strcmp((char*)event->data.scalar.value, ROS_QOS_PROFILE_DEFAULT_NAME) == 0)
                         *(Ros_QoS_Profile_Setting*)activeItem->valueToSet = ROS_QOS_PROFILE_DEFAULT;
                     else
                     {
@@ -314,7 +314,7 @@ void Ros_ConfigFile_CheckYamlEvent(yaml_event_t* event)
                         *(Ros_QoS_Profile_Setting*)activeItem->valueToSet = ROS_QOS_PROFILE_DEFAULT;
                         Ros_Debug_BroadcastMsg(
                             "Falling back to '%s' profile for '%s': unrecognised profile: '%s'",
-                            "default",
+                            ROS_QOS_PROFILE_DEFAULT_NAME,
                             (char*)activeItem->yamlKey,
                             (char*)event->data.scalar.value);
                     }
@@ -697,6 +697,23 @@ void Ros_ConfigFile_ValidateNonCriticalSettings()
     }
 }
 
+const char* const Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(Ros_QoS_Profile_Setting val)
+{
+    if (val == ROS_QOS_PROFILE_SENSOR_DATA)
+        return ROS_QOS_PROFILE_SENSOR_DATA_NAME;
+    if (val == ROS_QOS_PROFILE_PARAMETERS)
+        return ROS_QOS_PROFILE_PARAMETERS_NAME;
+    if (val == ROS_QOS_PROFILE_DEFAULT)
+        return ROS_QOS_PROFILE_DEFAULT_NAME;
+    if (val == ROS_QOS_PROFILE_SERVICES)
+        return ROS_QOS_PROFILE_SERVICES_NAME;
+    if (val == ROS_QOS_PROFILE_PARAMETER_EVENTS)
+        return ROS_QOS_PROFILE_PARAMETER_EVENTS_NAME;
+    if (val == ROS_QOS_PROFILE_SYSTEM_DEFAULT)
+        return ROS_QOS_PROFILE_SYSTEM_DEFAULT_NAME;
+    return ROS_QOS_PROFILE_UNKNOWN_NAME;
+}
+
 void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* const config)
 {
     Ros_Debug_BroadcastMsg("Config: ros_domain_id = %d", config->ros_domain_id);
@@ -727,9 +744,9 @@ void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* c
     Ros_Debug_BroadcastMsg("Config: executor_sleep_period = %d", config->executor_sleep_period);
     Ros_Debug_BroadcastMsg("Config: action_feedback_publisher_period = %d", config->action_feedback_publisher_period);
     Ros_Debug_BroadcastMsg("Config: controller_status_monitor_period = %d", config->controller_status_monitor_period);
-    Ros_Debug_BroadcastMsg("Config: robot_status = %d", config->qos_robot_status);
-    Ros_Debug_BroadcastMsg("Config: joint_states = %d", config->qos_joint_states);
-    Ros_Debug_BroadcastMsg("Config: tf = %d", config->qos_tf);
+    Ros_Debug_BroadcastMsg("Config: robot_status = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_robot_status));
+    Ros_Debug_BroadcastMsg("Config: joint_states = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_joint_states));
+    Ros_Debug_BroadcastMsg("Config: tf = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_tf));
     Ros_Debug_BroadcastMsg("Config: tf_frame_prefix = %s", config->tf_frame_prefix);
     Ros_Debug_BroadcastMsg("Config: stop_motion_on_disconnect = %d", config->stop_motion_on_disconnect);
     Ros_Debug_BroadcastMsg("Config: inform_job_name = %s", config->inform_job_name);

--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -716,7 +716,7 @@ void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* c
         for (int j = 0; j < MP_GRP_AXES_NUM; j += 1)
         {
             if (strlen(config->joint_names[(i * MP_GRP_AXES_NUM) + j]) > 0)
-                Ros_Debug_BroadcastMsg(config->joint_names[(i * MP_GRP_AXES_NUM) + j]);
+                Ros_Debug_BroadcastMsg("%s", config->joint_names[(i * MP_GRP_AXES_NUM) + j]);
             else
                 Ros_Debug_BroadcastMsg("x");
         }

--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -717,11 +717,11 @@ const char* const Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(Ros_QoS_Profile
 void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* const config)
 {
     Ros_Debug_BroadcastMsg("Config: ros_domain_id = %d", config->ros_domain_id);
-    Ros_Debug_BroadcastMsg("Config: node_name = %s", config->node_name);
-    Ros_Debug_BroadcastMsg("Config: node_namespace = %s", config->node_namespace);
-    Ros_Debug_BroadcastMsg("Config: remap_rules = %s", config->remap_rules);
-    Ros_Debug_BroadcastMsg("Config: agent_ip_address = %s", config->agent_ip_address);
-    Ros_Debug_BroadcastMsg("Config: agent_port_number = %s", config->agent_port_number);
+    Ros_Debug_BroadcastMsg("Config: node_name = '%s'", config->node_name);
+    Ros_Debug_BroadcastMsg("Config: node_namespace = '%s'", config->node_namespace);
+    Ros_Debug_BroadcastMsg("Config: remap_rules = '%s'", config->remap_rules);
+    Ros_Debug_BroadcastMsg("Config: agent_ip_address = '%s'", config->agent_ip_address);
+    Ros_Debug_BroadcastMsg("Config: agent_port_number = '%s'", config->agent_port_number);
     Ros_Debug_BroadcastMsg("Config: sync_timeclock_with_agent = %d", config->sync_timeclock_with_agent);
     Ros_Debug_BroadcastMsg("Config: namespace_tf = %d", config->namespace_tf);
     Ros_Debug_BroadcastMsg("Config: publish_tf = %d", config->publish_tf);
@@ -733,7 +733,7 @@ void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* c
         for (int j = 0; j < MP_GRP_AXES_NUM; j += 1)
         {
             if (strlen(config->joint_names[(i * MP_GRP_AXES_NUM) + j]) > 0)
-                Ros_Debug_BroadcastMsg("%s", config->joint_names[(i * MP_GRP_AXES_NUM) + j]);
+                Ros_Debug_BroadcastMsg("'%s'", config->joint_names[(i * MP_GRP_AXES_NUM) + j]);
             else
                 Ros_Debug_BroadcastMsg("x");
         }
@@ -744,12 +744,12 @@ void Ros_ConfigFile_PrintActiveConfiguration(Ros_Configuration_Settings const* c
     Ros_Debug_BroadcastMsg("Config: update_periods.executor_sleep_period = %d", config->executor_sleep_period);
     Ros_Debug_BroadcastMsg("Config: update_periods.action_feedback_publisher_period = %d", config->action_feedback_publisher_period);
     Ros_Debug_BroadcastMsg("Config: update_periods.controller_status_monitor_period = %d", config->controller_status_monitor_period);
-    Ros_Debug_BroadcastMsg("Config: publisher_qos.robot_status = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_robot_status));
-    Ros_Debug_BroadcastMsg("Config: publisher_qos.joint_states = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_joint_states));
-    Ros_Debug_BroadcastMsg("Config: publisher_qos.tf = %s", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_tf));
-    Ros_Debug_BroadcastMsg("Config: tf_frame_prefix = %s", config->tf_frame_prefix);
+    Ros_Debug_BroadcastMsg("Config: publisher_qos.robot_status = '%s'", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_robot_status));
+    Ros_Debug_BroadcastMsg("Config: publisher_qos.joint_states = '%s'", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_joint_states));
+    Ros_Debug_BroadcastMsg("Config: publisher_qos.tf = '%s'", Ros_ConfigFile_Rmw_Qos_ProfileSetting_ToString(config->qos_tf));
+    Ros_Debug_BroadcastMsg("Config: tf_frame_prefix = '%s'", config->tf_frame_prefix);
     Ros_Debug_BroadcastMsg("Config: stop_motion_on_disconnect = %d", config->stop_motion_on_disconnect);
-    Ros_Debug_BroadcastMsg("Config: inform_job_name = %s", config->inform_job_name);
+    Ros_Debug_BroadcastMsg("Config: inform_job_name = '%s'", config->inform_job_name);
     Ros_Debug_BroadcastMsg("Config: allow_custom_inform_job = %d", config->allow_custom_inform_job);
     Ros_Debug_BroadcastMsg("Config: userlan_monitor_enabled = %d", config->userlan_monitor_enabled);
     Ros_Debug_BroadcastMsg("Config: userlan_monitor_port = %d", config->userlan_monitor_port);

--- a/src/ConfigFile.h
+++ b/src/ConfigFile.h
@@ -74,6 +74,14 @@ typedef enum
     ROS_QOS_PROFILE_SYSTEM_DEFAULT = 6,
 } Ros_QoS_Profile_Setting;
 
+#define ROS_QOS_PROFILE_SENSOR_DATA_NAME "sensor_data"
+#define ROS_QOS_PROFILE_PARAMETERS_NAME "parameters"
+#define ROS_QOS_PROFILE_DEFAULT_NAME "default"
+#define ROS_QOS_PROFILE_SERVICES_NAME "services"
+#define ROS_QOS_PROFILE_PARAMETER_EVENTS_NAME "parameter_events"
+#define ROS_QOS_PROFILE_SYSTEM_DEFAULT_NAME "system_default"
+#define ROS_QOS_PROFILE_UNKNOWN_NAME "unknown"
+
 #define DEFAULT_REMAP_RULES             ""
 #define MAX_REMAP_RULE_NUM              16
 #define MAX_REMAP_RULE_LEN              256


### PR DESCRIPTION
Alternative to #84. This also adds the namespaces to the keys and refactors things slightly.

This is based on the work of @SejalBehere, but I've removed the changes to how things are parsed (ie: the `QoSMapping` and related types and functions are no longer used).

I decided to rework the PR a bit as it mixed two different things: we may want to extend the nr of supported QoS profiles in the future, but for now we're only interested in pretty-printing the complete configuration `struct`. That's what #33 asks for.

Functionally, this is largely equivalent to what @SejalBehere implemented in #84.

So thanks @SejalBehere for the work 👍 
