### PR TITLE
Move M+ constants to our M+ externs header

### DIFF
--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -14,14 +14,6 @@
 #define MOTION_START_CHECK_PERIOD           50  // in millisecond
 #define MOTION_STOP_TIMEOUT                 20
 
-#ifndef E_EXRCS_PFL_FUNC_BUSY
-#define E_EXRCS_PFL_FUNC_BUSY               (-19)
-#endif
-
-#ifndef E_EXRCS_UNDER_ENERGY_SAVING
-#define E_EXRCS_UNDER_ENERGY_SAVING         (-20)
-#endif
-
 typedef enum
 {
     MOTION_MODE_INACTIVE,

--- a/src/MotoPlusExterns.h
+++ b/src/MotoPlusExterns.h
@@ -24,4 +24,12 @@ extern MP_GRP_ID_TYPE mpCtrlGrpNo2GrpId(int grp_no);
 #define MAX_ERROR_COUNT 1
 #endif
 
+#ifndef E_EXRCS_PFL_FUNC_BUSY
+#define E_EXRCS_PFL_FUNC_BUSY               (-19)
+#endif
+
+#ifndef E_EXRCS_UNDER_ENERGY_SAVING
+#define E_EXRCS_UNDER_ENERGY_SAVING         (-20)
+#endif
+
 #endif // MOTOROS2_MOTOPLUS_EXTERNS_H


### PR DESCRIPTION
As per subject.

Minor.

These constants should ideally be defined by the M+ SDK itself (in `mpExtraRcs.h`), but apparently haven't been included yet.

They are not specific to MotoROS2, so let's treat them like other identifiers we need, but need to 'bring ourselves'.
