### PR TITLE
Use fixed-width format for motion ctrl traj pt debug output

### DIFF
--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -365,7 +365,7 @@ void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup)
                     continue;
                 }
 
-                Ros_Debug_BroadcastMsg("Processing next point in trajectory [Group #%d - T=%.3f: (%.4f, %.4f, %.4f, %.4f, %.4f, %.4f)]",
+                Ros_Debug_BroadcastMsg("Processing next point in trajectory [Group #%d - T=%.3f: (%7.4f, %7.4f, %7.4f, %7.4f, %7.4f, %7.4f)]",
                     ctrlGroup->groupNo, (double)ctrlGroup->trajectoryIterator->time * 0.001,
                     ctrlGroup->trajectoryIterator->pos[0], ctrlGroup->trajectoryIterator->pos[1], ctrlGroup->trajectoryIterator->pos[2],
                     ctrlGroup->trajectoryIterator->pos[3], ctrlGroup->trajectoryIterator->pos[4], ctrlGroup->trajectoryIterator->pos[5]);


### PR DESCRIPTION
As per subject.

Makes the debug log somewhat easier to read/parse.

Before this change:

```
...
Processing next point in trajectory [Group #0 - T=0.648: (0.0000, -1.5824, -1.3691, 0.0000, -0.4947, 0.0000)]
Processing next point in trajectory [Group #1 - T=0.648: (0.0500, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000)]
Processing next point in trajectory [Group #0 - T=0.826: (0.0000, -1.4835, -1.2835, 0.0000, -0.4638, 0.0000)]
Processing next point in trajectory [Group #1 - T=0.826: (0.0500, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000)]
...
```

After this change:

```
...
Processing next point in trajectory [Group #0 - T=0.543: (-0.0001, -0.1330, -0.1208, -0.0003, -0.1460,  0.0000)]
Processing next point in trajectory [Group #1 - T=0.667: ( 0.1153,  0.0000,  0.0000,  0.0000,  0.0000,  0.0000)]
Processing next point in trajectory [Group #0 - T=0.667: (-0.0001, -0.1995, -0.1813, -0.0003, -0.2191,  0.0000)]
Processing next point in trajectory [Group #1 - T=0.772: ( 0.1370,  0.0000,  0.0000,  0.0000,  0.0000,  0.0000)]
...
```
