### PR TITLE
Always output double digits when generating default node name

### DIFF
--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -156,7 +156,7 @@ void Ros_ConfigFile_SetAllDefaultValues()
 #endif
 
     //last three bytes of MAC ID are a unique identifier
-    sprintf(g_nodeConfigSettings.node_name, "%s_%2x_%2x_%2x", DEFAULT_NODE_NAME, macId[3], macId[4], macId[5]);
+    sprintf(g_nodeConfigSettings.node_name, "%s_%02x_%02x_%02x", DEFAULT_NODE_NAME, macId[3], macId[4], macId[5]);
 
     //=========
     //node_namespace


### PR DESCRIPTION
As per subject.

It's legal for MAC addresses to contain zeros. Before this change, those would be formatted as ` 0`. As the format specifies a two column field, whitespace would be used for the second column, ultimately leading to spaces in the node name.

Whitespace is illegal in ROS resource names (all ROS versions), leading to `RCL_RET_NODE_INVALID_NAME` errors being reported by `rclc_node_init_with_options(..)`.

To fix this, force `snprintf(..)` to use leading zeros instead of spaces.

This should fix #144, and probably also fixes #55.

Thanks to @acbuynak for reporting this.
