### PR TITLE
readme: clarify Rolling is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following general requirements must be met in order to be able to use MotoRO
   - YRC1000micro: either `LAN2` or `LAN3`
 - MotoPlus and Motoman-Driver must be enabled on the controller
 - ROS 2 version: Foxy, Galactic or Humble.
-  ROS 2 Iron Irwini is not yet supported.
+  MotoROS2 does not support ROS 2 Iron Irwini nor Rolling Ridley.
 - Docker or a from-source build of the micro-ROS Agent
 - FastDDS as RMW (even when using ROS 2 Galactic)
 


### PR DESCRIPTION
As per subject.

Just to make it extra clear.

Context: #148 (which probably wasn't caused by any incompatibility with Rolling, but it's still good to be clear about this).
