### PR TITLE
Port FSU speed limit handling from MotoROS1

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -417,7 +417,7 @@ void Ros_ActionServer_FJT_UpdateProgressTracker(MP_EXPOS_DATA* incrementData)
         Ros_CtrlGroup_ConvertToRosPos(ctrlGroup, incrementData->grp_pos_info[groupIndex].pos, radRosOrder);
 
         for (int i = 0; i < ctrlGroup->numAxes; i += 1, iteratorAllAxes += 1)
-            feedback_FollowJointTrajectory.feedback.desired.positions.data[iteratorAllAxes] += radRosOrder[i];
+            feedback_FollowJointTrajectory.feedback.desired.positions.data[iteratorAllAxes] = feedback_FollowJointTrajectory.feedback.actual.positions.data[iteratorAllAxes] + radRosOrder[i];
     }
 }
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -773,8 +773,6 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
     BOOL isMissingPulse;                                                // Flag that there are pulses send in last cycle that are missing from the command (pulses were not processed)
     BOOL hasUnprocessedData;                                            // Flag that at least one axis (any group) still has unprecessed data. (Used to continue sending data after the queue is empty.)
 
-    ctrlGrpData.sCtrlGrp = 0;
-
     bzero(newPulseInc, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
     bzero(toProcessPulses, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
     bzero(processedPulses, sizeof(LONG) * MP_GRP_AXES_NUM);
@@ -796,6 +794,8 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
     {
         moveData.ctrl_grp |= (0x01 << i);
         moveData.grp_pos_info[i].pos_tag.data[0] = Ros_CtrlGroup_GetAxisConfig(g_Ros_Controller.ctrlGroups[i]);
+
+        ctrlGrpData.sCtrlGrp = g_Ros_Controller.ctrlGroups[i]->groupId;
         mpGetPulsePos(&ctrlGrpData, &prevPulsePosData[i]);
     }
 
@@ -918,6 +918,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
                 // Get the current controller command position and substract the previous command position
                 // and check if it matches the amount if increment sent last cycle.  If it doesn't then
                 // some pulses are missing and the amount of unprocessed pulses needs to be added to this cycle.
+                ctrlGrpData.sCtrlGrp = g_Ros_Controller.ctrlGroups[i]->groupId;
                 mpGetPulsePos(&ctrlGrpData, &pulsePosData);
                 isMissingPulse = FALSE;
                 for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
@@ -1103,6 +1104,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
             hasUnprocessedData = FALSE;
             for (i = 0; i < g_Ros_Controller.numGroup; i++)
             {
+                ctrlGrpData.sCtrlGrp = g_Ros_Controller.ctrlGroups[i]->groupId;
                 mpGetPulsePos(&ctrlGrpData, &prevPulsePosData[i]);
             }
         }

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -751,17 +751,27 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
     MP_PULSE_POS_RSP_DATA prevPulsePosData[MAX_CONTROLLABLE_GROUPS];
     MP_PULSE_POS_RSP_DATA pulsePosData;
 
-    LONG newPulseInc[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];		// Pulse increments that we just retrieved from the incQueue
-    LONG toProcessPulses[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];	// Total pulses that still need to be sent to the command
-    LONG processedPulses[MP_GRP_AXES_NUM];							// Amount of pulses from the last command that were actually processed (accepted) 
-    LONG prevMaxSpeed[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
-    LONG prevMaxSpeedRemain[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
-    LONG maxSpeed[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
-    LONG maxSpeedRemain[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
-    BOOL skipReadingQ[MAX_CONTROLLABLE_GROUPS];
-    BOOL queueRead[MAX_CONTROLLABLE_GROUPS];
-    BOOL isMissingPulse;
-    BOOL hasUnprocessedData;
+    // --- FSU Speed Limit related ---
+    // When FSU speed limitation is active, some pulses for an interpolation cycle may not be processed by the controller.
+    // To track the true amount of pulses processed, we keep track of the command position and by substracting the
+    // the previous position from the current one, we can confirm the amount if pulses precessed.
+    // If the amount processed doesn't match the amount sent at the previous cycle, we resend the unprocessed pulses amount.
+    // To keep the motion smooth, the 'maximum speed' (max pulses per cycle) is tracked and used to skip reading
+    // more pulse increment from the queue if the amount of unprocessed pulses is larger than the detected speed.
+    // The 'maximum speed' is also used to prevent exceeding the commanded speed once the FSU Speed Limit is removed.
+    //
+    // The following set of variables are used to track FSU speed limitation.
+    LONG newPulseInc[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];         // Pulse increments that we just retrieved from the incQueue
+    LONG toProcessPulses[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];     // Total pulses that still need to be sent to the command
+    LONG processedPulses[MP_GRP_AXES_NUM];                              // Amount of pulses from the last command that were actually processed (accepted)
+    LONG maxSpeed[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];            // ROS speed (amount of pulses for one cycle from the data queue) that should not be exceeded
+    LONG maxSpeedRemain[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];      // Number of pulses (absolute) that remains to be processed at the 'maxSpeed'
+    LONG prevMaxSpeed[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];        // Previous data queue reading 'maxSpeed'
+    LONG prevMaxSpeedRemain[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];  // Previous data queue reading 'maxSpeedRemain'
+    BOOL skipReadingQ[MAX_CONTROLLABLE_GROUPS];                         // Flag indicating to skip reading more data from the increment queue (there is enough unprocessed from previous cycles remaining)
+    BOOL queueRead[MAX_CONTROLLABLE_GROUPS];                            // Flag indicating that new increment data was retrieve from the queue on this cycle.
+    BOOL isMissingPulse;                                                // Flag that there are pulses send in last cycle that are missing from the command (pulses were not processed)
+    BOOL hasUnprocessedData;                                            // Flag that at least one axis (any group) still has unprecessed data. (Used to continue sending data after the queue is empty.)
 
     ctrlGrpData.sCtrlGrp = 0;
 
@@ -797,16 +807,19 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
             && (Ros_MotionControl_HasDataInQueue() || hasUnprocessedData)
             && !g_Ros_Controller.bStopMotion)
         {
+            // For each control group, retrieve the new pulse increments for this cycle
             for (i = 0; i < g_Ros_Controller.numGroup; i++)
             {
                 queueRead[i] = FALSE;
                 if (skipReadingQ[i])
                 {
+                    // Reset skip flag and set position increment to 0
                     skipReadingQ[i] = FALSE;
                     bzero(&moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
                 }
                 else
                 {
+                    // Retrieve position increment from the queue.
                     q = &g_Ros_Controller.ctrlGroups[i]->inc_q;
 
                     // Lock the q before manipulating it
@@ -814,6 +827,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
                     {
                         if (q->cnt > 0)
                         {
+                            // Initialize moveData with the next data from the queue
                             inc_data_time = q->data[q->idx].time;
                             q_time = g_Ros_Controller.ctrlGroups[i]->q_time;
                             moveData.grp_pos_info[i].pos_tag.data[2] = q->data[q->idx].tool;
@@ -827,7 +841,10 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
                             q->idx = Q_OFFSET_IDX(q->idx, 1, Q_SIZE);
                             q->cnt--;
 
-                            // Check if complete interpolation period covered
+                            // Check if complete interpolation period covered.
+                            // (Because time period of data received from ROS may not be a multiple of the
+                            // controller interpolation clock period, the queue may contain partiel period and
+                            // more than one queue increment maybe required to complete the interpolation period)
                             while (q->cnt > 0)
                             {
                                 if ((q_time <= q->data[q->idx].time)
@@ -864,6 +881,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
                         }
                         else
                         {
+                            // Queue is empty, initialize to 0 pulse increment
                             moveData.grp_pos_info[i].pos_tag.data[2] = 0;
                             moveData.grp_pos_info[i].pos_tag.data[3] = MP_INC_PULSE_DTYPE;
                             moveData.grp_pos_info[i].pos_tag.data[4] = 0;
@@ -896,7 +914,10 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
                     }
                 }
 
-                // Check if pulses are missing from last increment
+                // Check if pulses are missing from last increment.
+                // Get the current controller command position and substract the previous command position
+                // and check if it matches the amount if increment sent last cycle.  If it doesn't then
+                // some pulses are missing and the amount of unprocessed pulses needs to be added to this cycle.
                 mpGetPulsePos(&ctrlGrpData, &pulsePosData);
                 isMissingPulse = FALSE;
                 for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
@@ -918,6 +939,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
                         hasUnprocessedData = TRUE;
                 }
 
+                // Check if pulses are missing which means that the FSU speed limit is enabled
                 if (isMissingPulse)
                 {
                     UINT64 max_inc;
@@ -1012,6 +1034,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
             // motion should continue.
             if (!g_Ros_Controller.bStopMotion && (g_Ros_Communication_AgentIsConnected || !g_nodeConfigSettings.stop_motion_on_disconnect))
             {
+                // Send pulse increment to the controller command position
                 ret = mpExRcsIncrementMove(&moveData);
 
                 Ros_ActionServer_FJT_UpdateProgressTracker(&moveData);
@@ -1021,6 +1044,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
 
             if (ret != 0)
             {
+                // Failure: command rejected by controller.
                 // Update controller status to help identify cause
                 Ros_Controller_IoStatusUpdate();
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -747,6 +747,36 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
     UINT64 q_time;
     int axis;
 
+    MP_CTRL_GRP_SEND_DATA ctrlGrpData;
+    MP_PULSE_POS_RSP_DATA pulsePosData;
+
+    LONG newPulseInc[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];		// Pulse increments that we just retrieved from the incQueue
+    LONG toProcessPulses[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];	// Total pulses that still need to be sent to the command
+    LONG processedPulses[MP_GRP_AXES_NUM];							// Amount of pulses from the last command that were actually processed (accepted) 
+    LONG prevMaxSpeed[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
+    LONG prevMaxSpeedRemain[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
+    LONG maxSpeed[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
+    LONG maxSpeedRemain[MAX_CONTROLLABLE_GROUPS][MP_GRP_AXES_NUM];
+    BOOL skipReadingQ[MAX_CONTROLLABLE_GROUPS];
+    BOOL queueRead[MAX_CONTROLLABLE_GROUPS];
+    BOOL isMissingPulse;
+    BOOL hasUnprocessedData;
+
+    ctrlGrpData.sCtrlGrp = 0;
+
+    memset(newPulseInc, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    memset(toProcessPulses, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    memset(processedPulses, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM);
+    memset(prevMaxSpeed, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    memset(prevMaxSpeedRemain, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    memset(maxSpeed, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    memset(maxSpeedRemain, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    memset(skipReadingQ, 0x00, sizeof(BOOL) * MAX_CONTROLLABLE_GROUPS);
+    memset(queueRead, 0x00, sizeof(BOOL) * MAX_CONTROLLABLE_GROUPS);
+
+    isMissingPulse = FALSE;
+    hasUnprocessedData = FALSE;
+
     Ros_Debug_BroadcastMsg("IncMoveTask Started");
 
     bzero(&moveData, sizeof(moveData));
@@ -762,81 +792,216 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
         mpClkAnnounce(MP_INTERPOLATION_CLK);
 
         if (Ros_Controller_IsMotionReady()
-            && Ros_MotionControl_HasDataInQueue()
+            && (Ros_MotionControl_HasDataInQueue() || hasUnprocessedData)
             && !g_Ros_Controller.bStopMotion)
         {
             for (i = 0; i < g_Ros_Controller.numGroup; i++)
             {
-                q = &g_Ros_Controller.ctrlGroups[i]->inc_q;
-
-                // Lock the q before manipulating it
-                if (mpSemTake(q->q_lock, Q_LOCK_TIMEOUT) == OK)
+                queueRead[i] = FALSE;
+                if (skipReadingQ[i])
                 {
-                    if (q->cnt > 0)
-                    {
-                        inc_data_time = q->data[q->idx].time;
-                        q_time = g_Ros_Controller.ctrlGroups[i]->q_time;
-                        moveData.grp_pos_info[i].pos_tag.data[2] = q->data[q->idx].tool;
-                        moveData.grp_pos_info[i].pos_tag.data[3] = q->data[q->idx].frame;
-                        moveData.grp_pos_info[i].pos_tag.data[4] = q->data[q->idx].user;
-
-                        memcpy(&moveData.grp_pos_info[i].pos, &q->data[q->idx].inc, sizeof(LONG) * MP_GRP_AXES_NUM);
-
-                        // increment index in the queue and decrease the count
-                        q->idx = Q_OFFSET_IDX(q->idx, 1, Q_SIZE);
-                        q->cnt--;
-
-                        // Check if complete interpolation period covered
-                        while (q->cnt > 0)
-                        {
-                            if ((q_time <= q->data[q->idx].time)
-                                && (q->data[q->idx].time - q_time <= g_Ros_Controller.interpolPeriod))
-                            {
-                                // next incMove is part of same interpolation period
-
-                                // check that information is in the same format
-                                if ((moveData.grp_pos_info[i].pos_tag.data[2] != q->data[q->idx].tool)
-                                    || (moveData.grp_pos_info[i].pos_tag.data[3] != q->data[q->idx].frame)
-                                    || (moveData.grp_pos_info[i].pos_tag.data[4] != q->data[q->idx].user))
-                                {
-                                    // Different format can't combine information
-                                    break;
-                                }
-
-                                // add next incMove to current incMove
-                                for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
-                                    moveData.grp_pos_info[i].pos[axis] += q->data[q->idx].inc[axis];
-                                inc_data_time = q->data[q->idx].time;
-
-                                // increment index in the queue and decrease the count
-                                q->idx = Q_OFFSET_IDX(q->idx, 1, Q_SIZE);
-                                q->cnt--;
-                            }
-                            else
-                            {
-                                // interpolation period complete
-                                break;
-                            }
-                        }
-
-                        g_Ros_Controller.ctrlGroups[i]->q_time = inc_data_time;
-                    }
-                    else
-                    {
-                        moveData.grp_pos_info[i].pos_tag.data[2] = 0;
-                        moveData.grp_pos_info[i].pos_tag.data[3] = MP_INC_PULSE_DTYPE;
-                        moveData.grp_pos_info[i].pos_tag.data[4] = 0;
-                        bzero(&moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
-                    }
-
-                    // Unlock the q
-                    mpSemGive(q->q_lock);
+                    skipReadingQ[i] = FALSE;
+                    bzero(&moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
                 }
                 else
                 {
-                    Ros_Debug_BroadcastMsg("ERROR: Can't get data from queue. Queue is locked up (Group #%d)", g_Ros_Controller.ctrlGroups[i]->groupNo);
-                    bzero(&moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
-                    continue;
+                    q = &g_Ros_Controller.ctrlGroups[i]->inc_q;
+
+                    // Lock the q before manipulating it
+                    if (mpSemTake(q->q_lock, Q_LOCK_TIMEOUT) == OK)
+                    {
+                        if (q->cnt > 0)
+                        {
+                            inc_data_time = q->data[q->idx].time;
+                            q_time = g_Ros_Controller.ctrlGroups[i]->q_time;
+                            moveData.grp_pos_info[i].pos_tag.data[2] = q->data[q->idx].tool;
+                            moveData.grp_pos_info[i].pos_tag.data[3] = q->data[q->idx].frame;
+                            moveData.grp_pos_info[i].pos_tag.data[4] = q->data[q->idx].user;
+
+                            memcpy(&moveData.grp_pos_info[i].pos, &q->data[q->idx].inc, sizeof(LONG) * MP_GRP_AXES_NUM);
+                            queueRead[i] = TRUE;
+
+                            // increment index in the queue and decrease the count
+                            q->idx = Q_OFFSET_IDX(q->idx, 1, Q_SIZE);
+                            q->cnt--;
+
+                            // Check if complete interpolation period covered
+                            while (q->cnt > 0)
+                            {
+                                if ((q_time <= q->data[q->idx].time)
+                                    && (q->data[q->idx].time - q_time <= g_Ros_Controller.interpolPeriod))
+                                {
+                                    // next incMove is part of same interpolation period
+
+                                    // check that information is in the same format
+                                    if ((moveData.grp_pos_info[i].pos_tag.data[2] != q->data[q->idx].tool)
+                                        || (moveData.grp_pos_info[i].pos_tag.data[3] != q->data[q->idx].frame)
+                                        || (moveData.grp_pos_info[i].pos_tag.data[4] != q->data[q->idx].user))
+                                    {
+                                        // Different format can't combine information
+                                        break;
+                                    }
+
+                                    // add next incMove to current incMove
+                                    for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                                        moveData.grp_pos_info[i].pos[axis] += q->data[q->idx].inc[axis];
+                                    inc_data_time = q->data[q->idx].time;
+
+                                    // increment index in the queue and decrease the count
+                                    q->idx = Q_OFFSET_IDX(q->idx, 1, Q_SIZE);
+                                    q->cnt--;
+                                }
+                                else
+                                {
+                                    // interpolation period complete
+                                    break;
+                                }
+                            }
+
+                            g_Ros_Controller.ctrlGroups[i]->q_time = inc_data_time;
+                        }
+                        else
+                        {
+                            moveData.grp_pos_info[i].pos_tag.data[2] = 0;
+                            moveData.grp_pos_info[i].pos_tag.data[3] = MP_INC_PULSE_DTYPE;
+                            moveData.grp_pos_info[i].pos_tag.data[4] = 0;
+                            bzero(&moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
+                        }
+
+                        // Unlock the q
+                        mpSemGive(q->q_lock);
+                    }
+                    else
+                    {
+                        Ros_Debug_BroadcastMsg("ERROR: Can't get data from queue. Queue is locked up (Group #%d)", g_Ros_Controller.ctrlGroups[i]->groupNo);
+                        bzero(&moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
+                        continue;
+                    }
+                }
+            }
+
+            for (i = 0; i < g_Ros_Controller.numGroup; i++)
+            {
+                memcpy(newPulseInc[i], moveData.grp_pos_info[i].pos, sizeof(LONG) * MP_GRP_AXES_NUM);
+
+                // record the speed associate with the next amount of pulses
+                if (queueRead[i])
+                {
+                    for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                    {
+                        maxSpeed[i][axis] = abs(newPulseInc[i][axis]);
+                        maxSpeedRemain[i][axis] = abs(newPulseInc[i][axis]);
+                    }
+                }
+
+                // Check if pulses are missing from last increment
+                mpGetPulsePos(&ctrlGrpData, &pulsePosData);
+                isMissingPulse = FALSE;
+                for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                {
+                    // Check how many pulses we processed from last increment
+                    processedPulses[axis] = pulsePosData.lPos[axis] - g_Ros_Controller.ctrlGroups[i]->prevPulsePosData[axis];
+                    g_Ros_Controller.ctrlGroups[i]->prevPulsePosData[axis] = pulsePosData.lPos[axis];
+
+                    // Remove those pulses from the amount to process.  
+                    // If everything was processed, then there should by 0 pulses left. Otherwise FSU Speed limit prevented processing
+                    toProcessPulses[i][axis] -= processedPulses[axis];
+                    if (toProcessPulses[i][axis] != 0)
+                        isMissingPulse = TRUE;
+
+                    // Add the new pulses to be processed for this iteration 
+                    toProcessPulses[i][axis] += newPulseInc[i][axis];
+
+                    if (toProcessPulses[i][axis] != 0)
+                        hasUnprocessedData = TRUE;
+                }
+
+                if (isMissingPulse)
+                {
+                    UINT64 max_inc;
+
+                    // Prevent going faster than original requested speed once speed limit turns off
+                    // Check if the speed (inc) of previous interation should be considered by checking 
+                    // if the unprocessed pulses from that speed setting still remains.
+                    // If all the pulses of previous increment were processed, then transfer the current 
+                    // speed and process the next increment from the increment queue.
+                    for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                    {
+                        // Check if has pulses to process
+                        if (toProcessPulses[i][axis] == 0)
+                            prevMaxSpeedRemain[i][axis] = 0;
+                        else
+                            prevMaxSpeedRemain[i][axis] = abs(prevMaxSpeedRemain[i][axis]) - abs(processedPulses[axis]);
+                    }
+
+                    // Check if still have data to process from previous iteration
+                    skipReadingQ[i] = FALSE;
+                    for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                    {
+                        if (prevMaxSpeedRemain[i][axis] > 0)
+                            skipReadingQ[i] = TRUE;
+                    }
+
+                    if (!skipReadingQ[i]) {
+                        for (axis = 0; axis < MP_GRP_AXES_NUM; axis++) {
+                            // Transfer the current speed as the new prevSpeed
+                            prevMaxSpeed[i][axis] = maxSpeed[i][axis];
+                            prevMaxSpeedRemain[i][axis] += maxSpeedRemain[i][axis];
+                        }
+                    }
+
+                    // Set the number of pulse that can be sent without exceeding speed
+                    for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                    {
+                        // Check if has pulses to process
+                        if (toProcessPulses[i][axis] == 0)
+                            continue;
+
+                        // Maximum inc that should be send ()
+                        if (prevMaxSpeed[i][axis] > 0)
+                            // if previous speed is defined use it
+                            max_inc = prevMaxSpeed[i][axis];
+                        else
+                        {
+                            if (maxSpeed[i][axis] > 0)
+                                // else fallback on current speed if defined
+                                max_inc = maxSpeed[i][axis];
+                            else if (newPulseInc[i][axis] != 0)
+                                // use the current speed if none zero.
+                                max_inc = abs(newPulseInc[i][axis]);
+                            else
+                                // otherwise use the axis max speed
+                                max_inc = g_Ros_Controller.ctrlGroups[i]->maxInc.maxIncrement[axis];
+
+                            if(max_inc > 1)
+                                Ros_Debug_BroadcastMsg("Warning undefined speed: Axis %d Defaulting Max Inc: %d (prevSpeed: %d curSpeed %d)\r\n",
+                                axis, max_inc, prevMaxSpeed[i][axis], maxSpeed[i][axis]);
+
+                        }
+
+                        // Set new increment and recalculate unsent pulses
+                        if (abs(toProcessPulses[i][axis]) <= max_inc)
+                        {
+                            // Pulses to send is small than max, so send everything
+                            moveData.grp_pos_info[i].pos[axis] = toProcessPulses[i][axis];
+                        }
+                        else {
+                            // Pulses to send is too high, so send the amount matching the maximum speed
+                            if (toProcessPulses[i][axis] >= 0)
+                                moveData.grp_pos_info[i].pos[axis] = max_inc;
+                            else
+                                moveData.grp_pos_info[i].pos[axis] = -max_inc;
+                        }
+                    }
+                }
+                else
+                {
+                    // No PFL Speed Limit detected
+                    for (axis = 0; axis < MP_GRP_AXES_NUM; axis++)
+                    {
+                        prevMaxSpeed[i][axis] = abs(moveData.grp_pos_info[i].pos[axis]);
+                        prevMaxSpeedRemain[i][axis] = abs(moveData.grp_pos_info[i].pos[axis]);
+                    }
                 }
             }
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -775,15 +775,15 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
 
     ctrlGrpData.sCtrlGrp = 0;
 
-    memset(newPulseInc, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
-    memset(toProcessPulses, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
-    memset(processedPulses, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM);
-    memset(prevMaxSpeed, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
-    memset(prevMaxSpeedRemain, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
-    memset(maxSpeed, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
-    memset(maxSpeedRemain, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
-    memset(skipReadingQ, 0x00, sizeof(BOOL) * MAX_CONTROLLABLE_GROUPS);
-    memset(queueRead, 0x00, sizeof(BOOL) * MAX_CONTROLLABLE_GROUPS);
+    bzero(newPulseInc, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    bzero(toProcessPulses, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    bzero(processedPulses, sizeof(LONG) * MP_GRP_AXES_NUM);
+    bzero(prevMaxSpeed, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    bzero(prevMaxSpeedRemain, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    bzero(maxSpeed, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    bzero(maxSpeedRemain, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+    bzero(skipReadingQ, sizeof(BOOL) * MAX_CONTROLLABLE_GROUPS);
+    bzero(queueRead, sizeof(BOOL) * MAX_CONTROLLABLE_GROUPS);
 
     isMissingPulse = FALSE;
     hasUnprocessedData = FALSE;
@@ -1099,7 +1099,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
         else
         {
             // Reset previous position in case the robot is moved externally
-            memset(toProcessPulses, 0x00, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
+            bzero(toProcessPulses, sizeof(LONG) * MP_GRP_AXES_NUM * MAX_CONTROLLABLE_GROUPS);
             hasUnprocessedData = FALSE;
             for (i = 0; i < g_Ros_Controller.numGroup; i++)
             {


### PR DESCRIPTION
As discussed at [here](https://github.com/ros-industrial/motoman/pull/542) I have implemented motoros2 version of FSU speed limit handling. Additionally, I have introduced following changes to resolve issues in the implementation:

1) `prevPulsePosData` is defined as global variable in `CtrlGroup`. This is required, since this variable is constantly changing in `Ros_MotionControl_IncMoveLoopStart` function. The `prevPulsePos` variable cannot be used instead, because it will break the logic of [`Ros_MotionControl_AddToIncQueueProcess`](https://github.com/iydv/motoros2/blob/75055e1e6b60f73e6abe80dab213f0e3ce889a1f/src/MotionControl.c#L518). 

This change is required to allow initialization of `prevPulsePosData` when trajectory mode is disabled/enabled. Otherwise, the robot will always tried to return to its last position every time the trajectory mode is enabled. 

2) `feedback_FollowJointTrajectory.feedback.desired.positions` is estimated differently now. Previously, it was accumulating all `moveData` increments in every iteration of `Ros_MotionControl_IncMoveLoopStart` function. However, the robot cannot reach desired increments due to the speed limit. Which means that `Ros_ActionServer_FJT_UpdateProgressTracker` function is called multiple times with increments that are never actually executed by the robot. 
I have changed `feedback_FollowJointTrajectory.feedback.desired.positions` to represent a current desired increment of actual positions, which better reflects the behavior of `Ros_MotionControl_IncMoveLoopStart` with current changes.
