### PR TITLE
Improve subcode doc linter: report heading parsing failures as errors

### DIFF
--- a/.ci/alarm_subcode_doc_linter.py
+++ b/.ci/alarm_subcode_doc_linter.py
@@ -243,7 +243,7 @@ def collapse_heading_children(headings):
     return [c["children"][0]["content"] for c in headings]
 
 
-alm_re = re.compile(r"\b(?:(\d{4})\[(?:(\d+)|(xx)|(\d+) \- (\d+))\])")
+alm_re = re.compile(r"\b(?:(\d{4})(?:\[(\d+)\]|\[(xx)\]|\[(\d+) \- (\d+)\]))$")
 
 
 def parse_alarm_code_with_subcode(subcode_spec) -> AlarmWithSubcodeRange:

--- a/.ci/alarm_subcode_doc_linter.py
+++ b/.ci/alarm_subcode_doc_linter.py
@@ -251,8 +251,13 @@ def parse_alarm_code_with_subcode(subcode_spec) -> AlarmWithSubcodeRange:
     turns "8010[1]", "8010[xx]" or "8010[1 - 2]"
     into
     (8010, 1, 1), (8010, 0, 65535) or (8010, 1, 2)
+
+    "8010[1] or [2]" and "8010[1 or 2]" will fail to parse and cause this method to return None.
     """
     groups = alm_re.findall(subcode_spec)
+    if not groups:
+        return None
+
     code, subcode_n, subcode_a, sc_range_s, sc_range_e = groups[0]
 
     def to_subcode_range(code, r_s, r_e):
@@ -264,7 +269,6 @@ def parse_alarm_code_with_subcode(subcode_spec) -> AlarmWithSubcodeRange:
         return to_subcode_range(code, SC_RANGE_MIN, SC_RANGE_MAX)
     if code and subcode_n:
         return to_subcode_range(code, subcode_n, subcode_n)
-    raise ValueError(f"Failed to parse range spec: '{subcode_spec}'")
 
 
 def find_subcode_doc(


### PR DESCRIPTION
This improves the alarm doc linter script and makes it report errors for each heading in the Markdown document it failed to parse.

Such parsing failures typically result in the same linter later reporting "no documentation" for a subcode, but without knowledge about the parsing failure such messages are misleading (and then lead to issues such as #160).

Example output (after introducing some errors in `doc/troubleshooting.md`):

```
doc/troubleshooting.md:663:0: error: failed to parse 'Alarm: 8011[56] - [58]'
doc/troubleshooting.md:691:0: error: failed to parse 'Alarm: 8011[60  62]'
doc/troubleshooting.md:849:0: error: failed to parse 'Alarm: 8013[8 or 9]'
doc/troubleshooting.md:920:0: error: failed to parse 'Alarm: 8013[14'
src/ErrorHandling.h:187:5: error: no documentation for '8013[8]' in 'doc/troubleshooting.md'
src/ErrorHandling.h:188:5: error: no documentation for '8013[9]' in 'doc/troubleshooting.md'
src/ErrorHandling.h:194:5: error: no documentation for '8013[14]' in 'doc/troubleshooting.md'
```
