### PR TITLE
Add controller-based conditional around the Inform TIMER instruction

### DIFF
--- a/src/InformCheckerAndGenerator.c
+++ b/src/InformCheckerAndGenerator.c
@@ -15,7 +15,13 @@ const char* rosInitJobLines[] =
     "NOP",
     "DOUT OT#(890) OFF",
     "DOUT OT#(889) OFF",
+#if defined(YRC1000) || defined(DX200) //DX2 and YRC use two digit precision on the TIMER
     "TIMER T=0.05",
+#elif defined(YRC1000u) || defined(FS100) //FS and YRCu use three digit precision on the TIMER
+    "TIMER T=0.050",
+#else
+#error Validate the precision of the TIMER instruction on the teach pendant and update this accordingly
+#endif
     "DOUT OT#(889) ON",
     "WAIT OT#(890)=ON",
     "DOUT OT#(890) OFF",


### PR DESCRIPTION
Fixes #166 
Based on https://github.com/gavanderhoorn/motoros2/commit/6a79f9bf9fe28e09c0c2f9f3e5d45eeadd0e07e1

Some controllers use three-digits for the `T` tag. Others use two.