### PR TITLE
Correct check for 'invalid motion type' (issue 178)

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -708,11 +708,11 @@ Please contact your local Yaskawa representative to request this function.
 
 ```text
 ALARM 8011
- Invalid motion type: N
+ Inv. motion type: N (axis: A)
 [63]
 ```
 
-Where `N` is an integer.
+Where `N` is an integer and `A` indicates the specific axis for which the motion type is invalid.
 
 *Solution:*
 MotoROS2 encountered an illegal value when evaluating base track coordinates for TF broadcast.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -712,7 +712,7 @@ ALARM 8011
 [63]
 ```
 
-Where `N` is an integer and `A` indicates the specific axis for which the motion type is invalid.
+Where `N` is an integer indicating the configured motion type and `A` indicates the specific axis for which the motion type is invalid.
 
 *Solution:*
 MotoROS2 encountered an illegal value when evaluating base track coordinates for TF broadcast.

--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -725,6 +725,15 @@ BOOL Ros_CtrlGroup_IsRobot(CtrlGroup* ctrlGroup)
 }
 
 //-------------------------------------------------------------------
+// Returns TRUE if the specified axis in the provided group is an
+// invalid one (ie: set to AXIS_INVALID)
+//-------------------------------------------------------------------
+BOOL Ros_CtrlGroup_IsInvalidAxis(CtrlGroup const* const ctrlGroup, size_t axisIdx)
+{
+    return ctrlGroup->axisType.type[axisIdx] == AXIS_INVALID;
+}
+
+//-------------------------------------------------------------------
 // Store the user-defined joint names in the CtrlGroup object using
 // "motoman" order. This will be used as a lookup table when receiving
 // a trajectory request. 

--- a/src/CtrlGroup.h
+++ b/src/CtrlGroup.h
@@ -129,6 +129,7 @@ extern void Ros_CtrlGroup_ConvertRosUnitsToMotoUnits(CtrlGroup* ctrlGroup, doubl
 extern UCHAR Ros_CtrlGroup_GetAxisConfig(CtrlGroup* ctrlGroup);
 
 extern BOOL Ros_CtrlGroup_IsRobot(CtrlGroup* ctrlGroup);
+extern BOOL Ros_CtrlGroup_IsInvalidAxis(CtrlGroup const* const ctrlGroup, size_t axisIdx);
 
 extern void Ros_CtrlGroup_UpdateJointNamesInMotoOrder(CtrlGroup* ctrlGroup);
 

--- a/src/PositionMonitor.c
+++ b/src/PositionMonitor.c
@@ -289,11 +289,16 @@ void Ros_PositionMonitor_CalculateTransforms(int groupIndex, long* pulsePos_moto
 
         //TODO: This isn't going to work for a motosweep
 
-        Ros_CtrlGroup_ConvertToRosPos(g_Ros_Controller.ctrlGroups[group->baseTrackGroupIndex], pulsePos_moto_track, track_pos_meters);
+        CtrlGroup* baseTrackGroup = g_Ros_Controller.ctrlGroups[group->baseTrackGroupIndex];
+        Ros_CtrlGroup_ConvertToRosPos(baseTrackGroup, pulsePos_moto_track, track_pos_meters);
 
         bzero(&coordTrackTravel, sizeof(MP_COORD));
         for (int i = 0; i < MAX_PULSE_AXES; i += 1)
         {
+            //skip if not a configured axis
+            if (Ros_CtrlGroup_IsInvalidAxis(baseTrackGroup, i))
+                continue;
+
             switch (group->baseTrackInfo.motionType[i])
             {
             case MOTION_TYPE_X: coordTrackTravel.x = METERS_TO_MICROMETERS(track_pos_meters[i]); break;

--- a/src/PositionMonitor.c
+++ b/src/PositionMonitor.c
@@ -309,8 +309,9 @@ void Ros_PositionMonitor_CalculateTransforms(int groupIndex, long* pulsePos_moto
             case MOTION_TYPE_RZ: coordTrackTravel.rz = RAD_TO_DEG_0001(track_pos_meters[i]); break;
             default:
                 //should never happen, so complain and raise alarm
-                snprintf(alarm_msg_buf, ERROR_MSG_MAX_SIZE, "Invalid motion type: %d", group->baseTrackInfo.motionType[i]);
-                Ros_Debug_BroadcastMsg("%s: %s", alarm_msg_buf);
+                snprintf(alarm_msg_buf, ERROR_MSG_MAX_SIZE, "Inv. motion type: %d (axis: %d)",
+                    group->baseTrackInfo.motionType[i], i);
+                Ros_Debug_BroadcastMsg("%s: %s", __func__, alarm_msg_buf);
                 motoRosAssert_withMsg(false, SUBCODE_FAIL_INVALID_BASE_TRACK_MOTION_TYPE, alarm_msg_buf);
             }
         }


### PR DESCRIPTION
Should fix #178 -- if I interpreted your https://github.com/Yaskawa-Global/motoros2/issues/178#issuecomment-1759760398 correctly @ted-miller.

Please do test this time :)

I'm not near a controller so can't test it myself, but I did want to fix the mistake I introduced in #176.
