### PR TITLE
Refactor: introduce getter for "does group have a base track associated?"

### DIFF
--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -733,6 +733,16 @@ BOOL Ros_CtrlGroup_IsInvalidAxis(CtrlGroup const* const ctrlGroup, size_t axisId
     return ctrlGroup->axisType.type[axisIdx] == AXIS_INVALID;
 }
 
+// Returns TRUE if the specified group has an associated base track
+//-------------------------------------------------------------------
+BOOL Ros_CtrlGroup_HasBaseTrack(CtrlGroup const* ctrlGroup)
+{
+    //according to the comment on CtrlGroup.h::CtrlGroup::baseTrackGroupIndex,
+    //checking for this to be != -1 should be sufficient to determine whether
+    //or not this group has a base track configured or not
+    return (ctrlGroup->baseTrackGroupIndex != -1);
+}
+
 //-------------------------------------------------------------------
 // Store the user-defined joint names in the CtrlGroup object using
 // "motoman" order. This will be used as a lookup table when receiving

--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -93,7 +93,7 @@ CtrlGroup* Ros_CtrlGroup_Create(int groupIndex, BOOL bIsLastGrpToInit, float int
 
             int baseIdOffset = (int)ctrlGroup->groupId - (int)MP_R1_GID;
             ctrlGroup->baseTrackGroupIndex = mpCtrlGrpId2GrpNo((MP_GRP_ID_TYPE)baseIdOffset + MP_B1_GID);
-            if (ctrlGroup->baseTrackGroupIndex != ERROR)
+            if (Ros_CtrlGroup_HasBaseTrack(ctrlGroup))
             {
                 ctrlGroup->baseTrackGroupId = (MP_GRP_ID_TYPE)(baseIdOffset + MP_B1_GID);
                 GP_getBaseAxisInfo(ctrlGroup->baseTrackGroupIndex, &ctrlGroup->baseTrackInfo);

--- a/src/CtrlGroup.h
+++ b/src/CtrlGroup.h
@@ -130,6 +130,7 @@ extern UCHAR Ros_CtrlGroup_GetAxisConfig(CtrlGroup* ctrlGroup);
 
 extern BOOL Ros_CtrlGroup_IsRobot(CtrlGroup* ctrlGroup);
 extern BOOL Ros_CtrlGroup_IsInvalidAxis(CtrlGroup const* const ctrlGroup, size_t axisIdx);
+extern BOOL Ros_CtrlGroup_HasBaseTrack(CtrlGroup const* ctrlGroup);
 
 extern void Ros_CtrlGroup_UpdateJointNamesInMotoOrder(CtrlGroup* ctrlGroup);
 

--- a/src/PositionMonitor.c
+++ b/src/PositionMonitor.c
@@ -281,7 +281,7 @@ void Ros_PositionMonitor_CalculateTransforms(int groupIndex, long* pulsePos_moto
 
     memcpy(&coordWorldToBase, &group->robotCalibrationToBaseFrame, sizeof(MP_COORD));
 
-    if (group->baseTrackGroupIndex != -1) //add in the offset of the base track motion and mounting offset
+    if (Ros_CtrlGroup_HasBaseTrack(group)) //add in the offset of the base track motion and mounting offset
     {
         MP_COORD coordTrackTravel;
         MP_FRAME frameTrackTravel, frameTrackToRobot, frameWorldToTrack;
@@ -416,7 +416,7 @@ void Ros_PositionMonitor_UpdateLocation()
         if (bRet != TRUE)
             continue;
         //if this is attached to a base track, get it's position too
-        if (group->baseTrackGroupIndex != -1)
+        if (Ros_CtrlGroup_HasBaseTrack(group))
             Ros_CtrlGroup_GetFBPulsePos(g_Ros_Controller.ctrlGroups[group->baseTrackGroupIndex], pulsePos_moto_track[groupIndex]);
 
         //----------------------------

--- a/src/Tests_CtrlGroup.c
+++ b/src/Tests_CtrlGroup.c
@@ -240,11 +240,36 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
     return bAllTestsPassed;
 }
 
+BOOL Ros_Testing_CtrlGroup_HasBaseTrack()
+{
+    CtrlGroup group;
+    BOOL bOk, bAllTestsPassed = TRUE;
+
+    //no base track
+    group.baseTrackGroupId = (MP_GRP_ID_TYPE)-1;
+    group.baseTrackGroupIndex = -1;
+
+    bOk = Ros_CtrlGroup_HasBaseTrack(&group) == FALSE;
+    Ros_Debug_BroadcastMsg("Testing CtrlGroup HasBaseTrack - no base track: %s", bOk ? "PASS" : "FAIL");
+    bAllTestsPassed &= bOk;
+
+    //has base track: R1+B1
+    group.baseTrackGroupId = MP_B1_GID;
+    group.baseTrackGroupIndex = 1;
+
+    bOk = Ros_CtrlGroup_HasBaseTrack(&group) == TRUE;
+    Ros_Debug_BroadcastMsg("Testing CtrlGroup HasBaseTrack - base track (B1): %s", bOk ? "PASS" : "FAIL");
+    bAllTestsPassed &= bOk;
+
+    return bAllTestsPassed;
+}
+
 BOOL Ros_Testing_CtrlGroup()
 {
     BOOL bSuccess = TRUE;
 
     bSuccess &= Ros_Testing_CtrlGroup_PosConverters();
+    bSuccess &= Ros_Testing_CtrlGroup_HasBaseTrack();
 
     return bSuccess;
 }


### PR DESCRIPTION
As per title.

No functional changes, just a simple refactor.

I also added a simple test to verify it works as I believe it should (based on the comment(s) in `CtrlGroup.h`):

```
Performing unit tests
Testing CtrlGroup ConvertToRosPos - 6 DOF style: PASS
Testing CtrlGroup ConvertToMotoPos - 6 DOF style: PASS
Testing CtrlGroup ConvertToRosPos - Delta style: PASS
Testing CtrlGroup ConvertToMotoPos - Delta style: PASS
Testing CtrlGroup ConvertToRosPos - SIA style: PASS
Testing CtrlGroup ConvertToMotoPos - SIA style: PASS
Testing CtrlGroup HasBaseTrack - no base track: PASS
Testing CtrlGroup HasBaseTrack - base track (B1): PASS
Testing Ros_MpCoord_To_GeomMsgsPose: PASS
Testing Ros_MpCoord_To_GeomMsgsTransform: PASS
Testing SUCCESSFUL
```
