### PR TITLE
Bump version as 0.1.3pre

### DIFF
--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -9,7 +9,7 @@
 #define MOTOROS2_MOTOROS_H
 
 #define APPLICATION_NAME            "MotoROS2"
-#define APPLICATION_VERSION         "0.1.2"
+#define APPLICATION_VERSION         "0.1.3pre"
 
 #include "motoPlus.h"
 


### PR DESCRIPTION
As per subject.

Facilitate distinguishing from-source builds from binary releases.
