### PR TITLE
ci: config md lint for our 'strong style'

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -16,3 +16,8 @@ MD013: false
 # explicitly allow it here
 MD033:
   allowed_elements: ['h1', 'img']
+
+# MD050 - Strong style
+# we use the double asterisk style throughout our documentation
+MD050:
+  style: asterisk


### PR DESCRIPTION
As per title.

Seems this check was added 'recently' to `mdlint` and we got that version in #202.

Not sure why this didn't trigger CI for that PR, but let's just fix it.
