### PR TITLE
Issue 114 Start Traj Mode failure exiting Eco Mode

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -190,11 +190,6 @@ rcl_ret_t Ros_ActionServer_FJT_Goal_Received(rclc_action_goal_handle_t* goal_han
 
         Ros_Debug_BroadcastMsg(responseMsg->message.data);
 
-        //Give time for the controller to recognize that the INFORM cursor is sitting on
-        //a WAIT instructions. Without this delay, the first call to mpExRcsIncrementMove
-        //will fail with a (-1).
-        Ros_Sleep(100);
-
         if (responseMsg->result_code.value == MOTION_READY)
             bMotionReady = Ros_Controller_IsMotionReady();
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1363,6 +1363,7 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
     MP_START_JOB_SEND_DATA sStartData;
     int checkCount;
     int grpNo;
+    bool ecoModeCheck = false;
 
     Ros_Debug_BroadcastMsg("%s: enter", __func__);
 
@@ -1441,6 +1442,7 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
                 Ros_Debug_BroadcastMsg("%s: couldn't disable eco mode");
                 goto updateStatus;
             }
+            ecoModeCheck = true;
         }
 
         // servos are off, eco mode is not active any more (if it was), so
@@ -1532,6 +1534,10 @@ updateStatus:
     Ros_Controller_IoStatusUpdate();
 
     Ros_Debug_BroadcastMsg("%s: exit", __func__);
+
+    //If recovering from eco mode: Give time for the controller to recognize that the INFORM cursor is sitting on
+    //a WAIT instructions.
+    if (ecoModeCheck) Ros_Sleep(200);
 
     if (Ros_Controller_IsMotionReady())
     {

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1363,7 +1363,6 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
     MP_START_JOB_SEND_DATA sStartData;
     int checkCount;
     int grpNo;
-    bool ecoModeCheck = false;
 
     Ros_Debug_BroadcastMsg("%s: enter", __func__);
 
@@ -1442,7 +1441,6 @@ BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode)
                 Ros_Debug_BroadcastMsg("%s: couldn't disable eco mode");
                 goto updateStatus;
             }
-            ecoModeCheck = true;
         }
 
         // servos are off, eco mode is not active any more (if it was), so
@@ -1535,9 +1533,8 @@ updateStatus:
 
     Ros_Debug_BroadcastMsg("%s: exit", __func__);
 
-    //If recovering from eco mode: Give time for the controller to recognize that the INFORM cursor is sitting on
-    //a WAIT instructions.
-    if (ecoModeCheck) Ros_Sleep(200);
+    //Required to allow motion api to work (Potential race condition)
+    Ros_Sleep(200);
 
     if (Ros_Controller_IsMotionReady())
     {


### PR DESCRIPTION
#114 Covers when /start_traj_mode fails while eco mode is set. While testing out /start_traj_mode I found that fjt also failed when in eco mode. By increasing the fjt delay and moving it into startMotionMode this got rid of eco issues with fjt and potentially resolves the start_traj_mode issues.

Tested on controller with no arm and controller with arm.
Test procedures:
1. Run microros
2. Hit e-stop
3. Reset e-stop
4. Send: ros2 service call /reset_error motoros2_interfaces/srv/ResetError
5. Send: ros2 service call /start_traj_mode motoros2_interfaces/srv/StartTrajMode
6. Wait until energy-saving mode turns on
7. Send fjt command