### PR TITLE
readme: don't start Agent as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ docker run \
   -it \
   --rm \
   --net=host \
+  --user=$(id -u):$(id -g) \
   microros/micro-ros-agent:humble \
     udp4 \
     --port 8888


### PR DESCRIPTION
As per title.

The Agent does not have to be run as `root` on Linux systems. The example command-line we show by default will do just that.

By adding `--user=$(id -u):$(id -g)` we ask Docker to start the Agent binary as the same user that runs the command, which is much better.
