### PR TITLE
Change `double` comparison to use epsilon instead of 0.0

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -503,7 +503,7 @@ void Ros_ActionServer_FJT_Goal_Complete(GOAL_END_TYPE goal_end_type)
             diff = fabs(feedback_FollowJointTrajectory.feedback.desired.positions.data[axis] - feedback_FollowJointTrajectory.feedback.actual.positions.data[axis]);
 
             double posTolerance = g_actionServer_FJT_SendGoal_Request.goal.goal_tolerance.data[axis].position; //user-provided a goal_tolerance
-            if (posTolerance == 0.0) //user did NOT provide a tolerance
+            if (fabs(posTolerance) < EPSILON_TOLERANCE_DOUBLE) //user did NOT provide a tolerance (posTolerance == 0.0)
                 posTolerance = DEFAULT_FJT_GOAL_POSITION_TOLERANCE;
 
             if (diff > posTolerance)


### PR DESCRIPTION
Regarding https://github.com/Yaskawa-Global/motoros2/issues/233#issuecomment-2045896777

I don't know if this will have an impact on #233. But it does seem like a potential problem.