### PR TITLE
Issue 233-outside goal tolerance

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -822,3 +822,7 @@ void Ros_ActionServer_FJT_ProcessResult()
         }
     }
 }
+
+
+//included here as this tests 'static' functions
+#include "Tests_ActionServer_FJT.c"

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -670,7 +670,8 @@ void Ros_ActionServer_FJT_Goal_Complete(GOAL_END_TYPE goal_end_type)
         {
             double current_jstate = feedback_FollowJointTrajectory.feedback.actual.positions.data[axis];
             diff = fabs(lastTrajPtPositions[axis] - current_jstate);
-            Ros_Debug_BroadcastMsg("desired - actual: %d, %d", (int)(1000 * lastTrajPtPositions[axis]), (int)(1000 * current_jstate));
+            Ros_Debug_BroadcastMsg("desired - actual: %12.8f - %12.8f: %12.8f",
+                lastTrajPtPositions[axis], current_jstate, diff);
 
             double chosen_posTolerance = posTolerance[axis];
             if (chosen_posTolerance == 0.0) //user did NOT provide a tolerance

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -532,7 +532,8 @@ static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
         Ros_Debug_BroadcastMsg("%s: parsing JointTolerance for '%s': pos: %f", __func__,
             selected_tolerance_name.data, goal_joint_tolerances->data[jtol_idx].position);
 
-        for (size_t ptol_idx = 0; ptol_idx < joint_names->size; ptol_idx += 1)
+        size_t ptol_idx = 0;
+        for (; ptol_idx < joint_names->size; ptol_idx += 1)
         {
             rosidl_runtime_c__String selected_position_name = joint_names->data[ptol_idx];
             if (rosidl_runtime_c__String__are_equal(&selected_position_name, &selected_tolerance_name))
@@ -542,6 +543,14 @@ static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
                 posTolerances[ptol_idx] = goal_joint_tolerances->data[jtol_idx].position;
                 break;
             }
+        }
+
+        //couldn't find joint
+        if (ptol_idx == joint_names->size)
+        {
+            //TODO(gavanderhoorn): make this a fatal error?
+            Ros_Debug_BroadcastMsg("%s: WARNING: couldn't find '%s' in internal joint names, ignoring",
+                __func__, selected_tolerance_name.data);
         }
     }
 

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -485,7 +485,7 @@ void Ros_ActionServer_FJT_ProcessFeedback()
 static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
     control_msgs__msg__JointTolerance__Sequence const* const goal_joint_tolerances /* in */,
     rosidl_runtime_c__String__Sequence const* const joint_names /* in */,
-    double* posTolerances /* in/out */, size_t posTolerances_len /* in */)
+    double* posTolerances /* out */, size_t posTolerances_len /* in */)
 {
     if (goal_joint_tolerances == NULL || joint_names == NULL || posTolerances == NULL)
     {

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -493,11 +493,13 @@ static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
         return -1;
     }
 
+    //always configure defaults
+    for (int i = 0; i < posTolerances_len; ++i)
+        posTolerances[i] = DEFAULT_FJT_GOAL_POSITION_TOLERANCE;
+
     //if caller hasn't passed any JointTolerances, set all entries to default
     if (goal_joint_tolerances->size == 0)
     {
-        for (int i = 0; i < posTolerances_len; ++i)
-            posTolerances[i] = DEFAULT_FJT_GOAL_POSITION_TOLERANCE;
         Ros_Debug_BroadcastMsg("%s: no joint tolerances specified, returning %d defaults",
             __func__, posTolerances_len);
         return OK;

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -547,6 +547,10 @@ static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
     return OK;
 }
 
+/**
+ * Note: this assumes neither 'traj_point_names' nor 'internal_jnames' contain
+ * duplicate joint names. This function does not check whether this is true.
+ */
 static STATUS Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
     trajectory_msgs__msg__JointTrajectoryPoint const* const traj_point /* in */,
     rosidl_runtime_c__String__Sequence const* const traj_point_jnames /* in */,
@@ -571,6 +575,13 @@ static STATUS Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
         Ros_Debug_BroadcastMsg("%s: partial traj pt not supported (%d pos, need: %d)",
             __func__, traj_point->positions.size, internal_jnames->size);
         return -3;
+    }
+
+    if (trajPtValues_len < traj_point->positions.size)
+    {
+        Ros_Debug_BroadcastMsg("%s: output array too small: %d < %d (nr of joints)",
+            __func__, trajPtValues_len, traj_point->positions.size);
+        return -4;
     }
 
     //this:

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -529,7 +529,7 @@ static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
     for (size_t jtol_idx = 0; jtol_idx < goal_joint_tolerances->size; jtol_idx +=1)
     {
         rosidl_runtime_c__String selected_tolerance_name = goal_joint_tolerances->data[jtol_idx].name;
-        Ros_Debug_BroadcastMsg("%s: found position tolerance: %s, %f", __func__,
+        Ros_Debug_BroadcastMsg("%s: parsing JointTolerance for '%s': pos: %f", __func__,
             selected_tolerance_name.data, goal_joint_tolerances->data[jtol_idx].position);
 
         for (size_t ptol_idx = 0; ptol_idx < joint_names->size; ptol_idx += 1)
@@ -537,7 +537,8 @@ static STATUS Ros_ActionServer_FJT_Parse_GoalPosTolerances(
             rosidl_runtime_c__String selected_position_name = joint_names->data[ptol_idx];
             if (rosidl_runtime_c__String__are_equal(&selected_position_name, &selected_tolerance_name))
             {
-                Ros_Debug_BroadcastMsg("%s: using position tolerance: %s", __func__, selected_position_name.data);
+                Ros_Debug_BroadcastMsg("%s: mapping '%s' (at %d) to internal index %d",
+                    __func__, selected_position_name.data, jtol_idx, ptol_idx);
                 posTolerances[ptol_idx] = goal_joint_tolerances->data[jtol_idx].position;
                 break;
             }
@@ -598,8 +599,8 @@ static STATUS Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
             if (rosidl_runtime_c__String__are_equal(&internal_jname, &traj_jname))
             {
                 trajPtValues[internal_jname_idx] = traj_point->positions.data[traj_jname_idx];
-                Ros_Debug_BroadcastMsg("%s: '%s' at %d: %f",
-                    __func__, internal_jname.data, internal_jname_idx, trajPtValues[internal_jname_idx]);
+                Ros_Debug_BroadcastMsg("%s: mapping ('%s'; %f) at %d to internal index %d",
+                    __func__, traj_jname.data, trajPtValues[internal_jname_idx], traj_jname_idx, internal_jname_idx);
                 break;
             }
         }

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -686,7 +686,7 @@ void Ros_ActionServer_FJT_Goal_Complete(GOAL_END_TYPE goal_end_type)
         {
             double current_jstate = feedback_FollowJointTrajectory.feedback.actual.positions.data[axis];
             diff = fabs(lastTrajPtPositions[axis] - current_jstate);
-            Ros_Debug_BroadcastMsg("desired - actual: %12.8f - %12.8f: %12.8f",
+            Ros_Debug_BroadcastMsg("target pos (%12.8f) - actual pos (%12.8f) = (%12.8f)",
                 lastTrajPtPositions[axis], current_jstate, diff);
 
             double chosen_posTolerance = posTolerance[axis];

--- a/src/ErrorHandling.h
+++ b/src/ErrorHandling.h
@@ -60,6 +60,7 @@ typedef enum
     FAIL_TRAJ_POSITION,
     FAIL_TRAJ_TIME,
     FAIL_TRAJ_ALARM,
+    FAIL_TRAJ_TOLERANCE_PARSE,
 } Failed_Trajectory_Status;
 
 //**********************************************************************

--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -102,6 +102,7 @@
 #include "Tests_TestUtils.h"
 #include "Tests_RosMotoPlusConversionUtils.h"
 #include "Tests_ControllerStatusIO.h"
+#include "Tests_ActionServer_FJT.h"
 #include "FauxCommandLineArgs.h"
 #include "InformCheckerAndGenerator.h"
 #include "MathConstants.h"

--- a/src/MotoROS2_AllControllers.vcxproj
+++ b/src/MotoROS2_AllControllers.vcxproj
@@ -343,6 +343,7 @@
     <ClCompile Include="ServiceStopTrajMode.c" />
     <ClCompile Include="ServiceStartTrajMode.c" />
     <ClCompile Include="ServiceSelectMotionTool.c" />
+    <ClCompile Include="Tests_ActionServer_FJT.c" />
     <ClCompile Include="Tests_ControllerStatusIO.c" />
     <ClCompile Include="Tests_CtrlGroup.c" />
     <ClCompile Include="Tests_TestUtils.c" />
@@ -376,6 +377,7 @@
     <ClInclude Include="ServiceStopTrajMode.h" />
     <ClInclude Include="ServiceStartTrajMode.h" />
     <ClInclude Include="ServiceSelectMotionTool.h" />
+    <ClInclude Include="Tests_ActionServer_FJT.h" />
     <ClInclude Include="Tests_ControllerStatusIO.h" />
     <ClInclude Include="Tests_CtrlGroup.h" />
     <ClInclude Include="Tests_TestUtils.h" />

--- a/src/Tests_ActionServer_FJT.c
+++ b/src/Tests_ActionServer_FJT.c
@@ -368,6 +368,316 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins(
     return bSuccess;
 }
 
+BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_null_args()
+{
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    trajectory_msgs__msg__JointTrajectoryPoint traj_point;
+    rosidl_runtime_c__String__Sequence traj_point_jnames;
+    rosidl_runtime_c__String__Sequence internal_jnames;
+    const size_t NUM_JOINTS = 6;
+    double trajPtValues[NUM_JOINTS];
+    bzero(trajPtValues, sizeof(trajPtValues));
+
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        NULL, &traj_point_jnames, &internal_jnames, trajPtValues, NUM_JOINTS);
+    BOOL bT00 = status == -1;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: traj_point NULL: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    status = 0;
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, NULL, &internal_jnames, trajPtValues, NUM_JOINTS);
+    BOOL bT01 = status == -1;
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: traj_point_jnames NULL: %s", __func__, bT01 ? "PASS" : "FAIL");
+
+    status = 0;
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, NULL, trajPtValues, NUM_JOINTS);
+    BOOL bT02 = status == -1;
+    bSuccess &= bT02;
+    Ros_Debug_BroadcastMsg("Testing %s: internal_jnames NULL: %s", __func__, bT02 ? "PASS" : "FAIL");
+
+    status = 0;
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, &internal_jnames, NULL, NUM_JOINTS);
+    BOOL bT03 = status == -1;
+    bSuccess &= bT03;
+    Ros_Debug_BroadcastMsg("Testing %s: trajPtValues NULL: %s", __func__, bT03 ? "PASS" : "FAIL");
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_jnames_len_neq()
+{
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    trajectory_msgs__msg__JointTrajectoryPoint traj_point;
+    rosidl_runtime_c__String__Sequence traj_point_jnames;
+    rosidl_runtime_c__String__Sequence internal_jnames;
+    const size_t NUM_JOINTS = 6;
+    double trajPtValues[NUM_JOINTS];
+    bzero(trajPtValues, sizeof(trajPtValues));
+
+    //add 1 traj joint name
+    rosidl_runtime_c__String__Sequence__init(&traj_point_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[0], "joint0");
+    traj_point_jnames.size = 1;
+
+    //add 2 joint names
+    rosidl_runtime_c__String__Sequence__init(&internal_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&internal_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[1], "joint1");
+    internal_jnames.size = 2;
+
+    //call
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, &internal_jnames, trajPtValues, NUM_JOINTS);
+
+    BOOL bT00 = status == -2;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: partial pt names: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    rosidl_runtime_c__String__Sequence__fini(&internal_jnames);
+    rosidl_runtime_c__String__Sequence__fini(&traj_point_jnames);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_traj_pt_jnames_neq()
+{
+    //try to re-order values for a trajectory point which doesn't have a sufficient
+    //nr of position values (at least not when compared to the nr of internal joint
+    //names).
+    //This requires us to setup an equal nr of joint names for the trajectory point
+    //as well as the internal joint names, but a different nr of position values in
+    //the traj pt 'positions' array. That would be an 'illegal' traj pt (and
+    //probably would be caught earlier than this function), but that's on purpose
+    //here of course in this test.
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    trajectory_msgs__msg__JointTrajectoryPoint traj_point;
+    rosidl_runtime_c__String__Sequence traj_point_jnames;
+    rosidl_runtime_c__String__Sequence internal_jnames;
+    const size_t NUM_JOINTS = 6;
+    double trajPtValues[NUM_JOINTS];
+    bzero(trajPtValues, sizeof(trajPtValues));
+
+    //add a single position value: this creates an invalid traj pt, but that's
+    //on purpose of course
+    bzero(&traj_point, sizeof(traj_point));
+    trajectory_msgs__msg__JointTrajectoryPoint__init(&traj_point);
+    traj_point.positions.data[0] = 0.0;
+    traj_point.positions.size = 1;
+
+    //add 2 traj joint names
+    rosidl_runtime_c__String__Sequence__init(&traj_point_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[1], "joint1");
+    traj_point_jnames.size = 2;
+
+    //add 2 joint names
+    rosidl_runtime_c__String__Sequence__init(&internal_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&internal_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[1], "joint1");
+    internal_jnames.size = 2;
+
+    //call
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, &internal_jnames, trajPtValues, NUM_JOINTS);
+
+    BOOL bT00 = status == -3;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: partial pt pos: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    rosidl_runtime_c__String__Sequence__fini(&internal_jnames);
+    rosidl_runtime_c__String__Sequence__fini(&traj_point_jnames);
+    trajectory_msgs__msg__JointTrajectoryPoint__fini(&traj_point);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_out_array_too_small()
+{
+    //try to re-order values for a trajectory point while the output array is
+    //too small.
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    trajectory_msgs__msg__JointTrajectoryPoint traj_point;
+    rosidl_runtime_c__String__Sequence traj_point_jnames;
+    rosidl_runtime_c__String__Sequence internal_jnames;
+    const size_t NUM_JOINTS = 6;
+
+    //make output array of size 1
+    const size_t OUTPUT_ARRAY_SZ = 1;
+    double trajPtValues[OUTPUT_ARRAY_SZ];
+    bzero(trajPtValues, sizeof(trajPtValues));
+
+    bzero(&traj_point, sizeof(traj_point));
+    trajectory_msgs__msg__JointTrajectoryPoint__init(&traj_point);
+    rosidl_runtime_c__double__Sequence__init(&traj_point.positions, NUM_JOINTS);
+    traj_point.positions.data[0] = 0.0;
+    traj_point.positions.data[1] = 0.0;
+    traj_point.positions.size = 2;
+
+    //add 2 traj joint names
+    rosidl_runtime_c__String__Sequence__init(&traj_point_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[1], "joint1");
+    traj_point_jnames.size = 2;
+
+    //add 2 joint names
+    rosidl_runtime_c__String__Sequence__init(&internal_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&internal_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[1], "joint1");
+    internal_jnames.size = 2;
+
+    //call
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, &internal_jnames, trajPtValues, OUTPUT_ARRAY_SZ);
+
+    BOOL bT00 = status == -4;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: out array too small: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    rosidl_runtime_c__String__Sequence__fini(&internal_jnames);
+    rosidl_runtime_c__String__Sequence__fini(&traj_point_jnames);
+    trajectory_msgs__msg__JointTrajectoryPoint__fini(&traj_point);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_single_jt()
+{
+    //try to re-order values for a trajectory point for a single joint
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    trajectory_msgs__msg__JointTrajectoryPoint traj_point;
+    rosidl_runtime_c__String__Sequence traj_point_jnames;
+    rosidl_runtime_c__String__Sequence internal_jnames;
+    const size_t NUM_JOINTS = 6;
+    double trajPtValues[NUM_JOINTS];
+    bzero(trajPtValues, sizeof(trajPtValues));
+
+    bzero(&traj_point, sizeof(traj_point));
+    trajectory_msgs__msg__JointTrajectoryPoint__init(&traj_point);
+    rosidl_runtime_c__double__Sequence__init(&traj_point.positions, NUM_JOINTS);
+    traj_point.positions.data[0] = 1.234;
+    traj_point.positions.size = 1;
+
+    //add 1 traj joint name
+    rosidl_runtime_c__String__Sequence__init(&traj_point_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[0], "joint0");
+    traj_point_jnames.size = 1;
+
+    //add 1 joint name
+    rosidl_runtime_c__String__Sequence__init(&internal_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&internal_jnames.data[0], "joint0");
+    internal_jnames.size = 1;
+
+    //call
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, &internal_jnames, trajPtValues, NUM_JOINTS);
+
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    //expect pos val for 'joint0' in first pos of output array
+    BOOL bT01 = trajPtValues[0] == 1.234;
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: j0 pos at [%d]: %s", __func__, 0, bT01 ? "PASS" : "FAIL");
+
+    rosidl_runtime_c__String__Sequence__fini(&internal_jnames);
+    rosidl_runtime_c__String__Sequence__fini(&traj_point_jnames);
+    trajectory_msgs__msg__JointTrajectoryPoint__fini(&traj_point);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_6_jt_reorder()
+{
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    trajectory_msgs__msg__JointTrajectoryPoint traj_point;
+    rosidl_runtime_c__String__Sequence traj_point_jnames;
+    rosidl_runtime_c__String__Sequence internal_jnames;
+    const size_t NUM_JOINTS = 6;
+    double trajPtValues[NUM_JOINTS];
+
+    bzero(&traj_point, sizeof(traj_point));
+    trajectory_msgs__msg__JointTrajectoryPoint__init(&traj_point);
+    rosidl_runtime_c__double__Sequence__init(&traj_point.positions, NUM_JOINTS);
+    traj_point.positions.data[0] = 0.123;
+    traj_point.positions.data[1] = 1.234;
+    traj_point.positions.data[2] = 2.345;
+    traj_point.positions.data[3] = 3.456;
+    traj_point.positions.data[4] = 4.567;
+    traj_point.positions.data[5] = 5.678;
+    traj_point.positions.size = 6;
+
+    //add 6 traj joint names
+    rosidl_runtime_c__String__Sequence__init(&traj_point_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[1], "joint1");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[2], "joint2");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[3], "joint3");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[4], "joint4");
+    rosidl_runtime_c__String__assign(&traj_point_jnames.data[5], "joint5");
+    traj_point_jnames.size = 6;
+
+    //add 6 joint names (note: different order)
+    rosidl_runtime_c__String__Sequence__init(&internal_jnames, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&internal_jnames.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[2], "joint1");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[4], "joint2");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[1], "joint3");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[5], "joint4");
+    rosidl_runtime_c__String__assign(&internal_jnames.data[3], "joint5");
+    internal_jnames.size = 6;
+
+    //call
+    status = Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order(
+        &traj_point, &traj_point_jnames, &internal_jnames, trajPtValues, NUM_JOINTS);
+
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    //check values are in the correct order
+    BOOL bT01 = (
+           trajPtValues[0] == 0.123
+        && trajPtValues[1] == 3.456
+        && trajPtValues[2] == 1.234
+        && trajPtValues[3] == 5.678
+        && trajPtValues[4] == 2.345
+        && trajPtValues[5] == 4.567);
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: value reordering: %s", __func__, bT01 ? "PASS" : "FAIL");
+
+    rosidl_runtime_c__String__Sequence__fini(&internal_jnames);
+    rosidl_runtime_c__String__Sequence__fini(&traj_point_jnames);
+    trajectory_msgs__msg__JointTrajectoryPoint__fini(&traj_point);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
 BOOL Ros_Testing_ActionServer_FJT()
 {
     BOOL bSuccess = TRUE;
@@ -386,6 +696,19 @@ BOOL Ros_Testing_ActionServer_FJT()
     bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot2();
     Ros_Debug_BroadcastMsg("~~~");
     bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins();
+
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_null_args();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_jnames_len_neq();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_traj_pt_jnames_neq();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_out_array_too_small();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_single_jt();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_6_jt_reorder();
     Ros_Debug_BroadcastMsg("~~~");
 
     return bSuccess;

--- a/src/Tests_ActionServer_FJT.c
+++ b/src/Tests_ActionServer_FJT.c
@@ -1,0 +1,394 @@
+// Tests_ActionServer_FJT.c
+
+// SPDX-FileCopyrightText: 2024, Yaskawa America, Inc.
+// SPDX-FileCopyrightText: 2024, Delft University of Technology
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#ifdef MOTOROS2_TESTING_ENABLE
+
+#include "MotoROS.h"
+#include <control_msgs/msg/joint_tolerance.h>
+
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_null_args()
+{
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 6;
+    double posTolerances[NUM_JOINTS];
+
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(NULL, &joint_names, posTolerances, NUM_JOINTS);
+
+    BOOL bT00 = status == -1;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: goal_joint_tolerances NULL: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    status = 0;
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, NULL, posTolerances, NUM_JOINTS);
+
+    BOOL bT01 = status == -1;
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: joint_names NULL: %s", __func__, bT01 ? "PASS" : "FAIL");
+
+    status = 0;
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, NULL, NUM_JOINTS);
+
+    BOOL bT02 = status == -1;
+    bSuccess &= bT02;
+    Ros_Debug_BroadcastMsg("Testing %s: posTolerances NULL: %s", __func__, bT02 ? "PASS" : "FAIL");
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_empty_jtolerances()
+{
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 6;
+    double posTolerances[NUM_JOINTS];
+
+    //init capacity to NUM_JOINTS, but don't add any elements
+    control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
+    joint_tolerances.size = 0;
+
+    //this should now return OK, and init posTolerances to all defaults
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
+
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    BOOL bT01 = (posTolerances[0] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[1] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[2] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[3] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[4] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[5] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                );
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: all defaults: %s", __func__, bT01 ? "PASS" : "FAIL");
+
+    control_msgs__msg__JointTolerance__Sequence__fini(&joint_tolerances);
+    rosidl_runtime_c__String__Sequence__fini(&joint_names);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_too_small()
+{
+    //output array of size == 1, two joints, single JointTolerance instance in goal.
+    //success if 'output array too small' return value is returned
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance joint_tolerance;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 6;
+
+    //make output array of size 1
+    const size_t OUTPUT_ARRAY_SZ = 1;
+    double posTolerances[OUTPUT_ARRAY_SZ];
+
+    //add 2 joint names
+    rosidl_runtime_c__String__Sequence__init(&joint_names, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&joint_names.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&joint_names.data[1], "joint1");
+    joint_names.size = 2;
+
+    control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
+    joint_tolerances.size = 0;
+
+    //add (at least) a single JointTolerance (don't need to init it, just add it)
+    bzero(&joint_tolerance, sizeof(joint_tolerance));
+    control_msgs__msg__JointTolerance__init(&joint_tolerance);
+    joint_tolerances.data[0] = joint_tolerance;
+    joint_tolerances.size = 1;
+
+    //call
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, OUTPUT_ARRAY_SZ);
+
+    BOOL bT00 = status == -2;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: out array too small: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    control_msgs__msg__JointTolerance__Sequence__fini(&joint_tolerances);
+    rosidl_runtime_c__String__Sequence__fini(&joint_names);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_than_jnames()
+{
+    //hypothetical controller with zero joints (so zero joint names, normal sized output array),
+    //but goal with single JointTolerance instance.
+    //success if JointTolerance is 'ignored'.
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance joint_tolerance;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 6;
+
+    //zero jnames, zero output array sz
+    double posTolerances[NUM_JOINTS];
+    rosidl_runtime_c__String__Sequence__init(&joint_names, NUM_JOINTS);
+    joint_names.size = 1;
+
+    control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
+    joint_tolerances.size = 0;
+
+    //add a single JointTolerance
+    bzero(&joint_tolerance, sizeof(joint_tolerance));
+    control_msgs__msg__JointTolerance__init(&joint_tolerance);
+    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint5");
+    joint_tolerance.position = 1.0;
+    joint_tolerances.data[0] = joint_tolerance;
+    joint_tolerances.size = 1;
+
+    //no jnames, zero len output array, but 1 jtol: that's legal, just means the jtol
+    //will essentially be ignored
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
+
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    //should have everything set to defaults (as JointTolerance is ignored)
+    BOOL bT01 = (posTolerances[0] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[1] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[2] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[3] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[4] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE
+                    && posTolerances[5] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE);
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: all defaults: %s", __func__, bT01 ? "PASS" : "FAIL");
+
+    control_msgs__msg__JointTolerance__Sequence__fini(&joint_tolerances);
+    rosidl_runtime_c__String__Sequence__fini(&joint_names);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot0()
+{
+    //hypothetical controller with single joint, goal with single JointTolerance instance.
+    //success if JointTolerance position value == first element in output array.
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance joint_tolerance;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 6;
+    const char JOINT_NAME[] = "joint0";
+    const double J0_POS_TOL = 1.0;
+    double posTolerances[NUM_JOINTS];
+    bzero(posTolerances, NUM_JOINTS);
+
+    rosidl_runtime_c__String__Sequence__init(&joint_names, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&joint_names.data[0], JOINT_NAME);
+    joint_names.size = 1;
+
+    //add a single JointTolerance
+    control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
+    joint_tolerances.size = 0;
+
+    bzero(&joint_tolerance, sizeof(joint_tolerance));
+    control_msgs__msg__JointTolerance__init(&joint_tolerance);
+    rosidl_runtime_c__String__assign(&joint_tolerance.name, JOINT_NAME);
+    joint_tolerance.position = J0_POS_TOL;
+    joint_tolerance.velocity = 0.0;
+    joint_tolerance.acceleration = 0.0;
+    joint_tolerances.data[0] = joint_tolerance;
+    joint_tolerances.size = 1;
+
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
+
+    //call itself must succeed
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    //expect position tolerance for 'joint0' in first pos of output array
+    //NOTE: using equals, as position tolerance should have been directly copied
+    BOOL bT01 = posTolerances[0] == J0_POS_TOL;
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: expected j0 pos tol: %s", __func__, bT01 ? "PASS" : "FAIL");
+
+    control_msgs__msg__JointTolerance__Sequence__fini(&joint_tolerances);
+    rosidl_runtime_c__String__Sequence__fini(&joint_names);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot2()
+{
+    //hypothetical controller with single joint, goal with single JointTolerance instance.
+    //success if JointTolerance position value == third element in output array.
+
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance joint_tolerance;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 6;
+    const size_t JOINT0_IDX = 2;
+    const char JOINT_NAME[] = "joint0";
+    const double J0_POS_TOL = 1.0;
+    double posTolerances[NUM_JOINTS];
+    bzero(posTolerances, NUM_JOINTS);
+
+    rosidl_runtime_c__String__Sequence__init(&joint_names, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&joint_names.data[0], "joint1");
+    rosidl_runtime_c__String__assign(&joint_names.data[1], "joint2");
+    rosidl_runtime_c__String__assign(&joint_names.data[JOINT0_IDX], JOINT_NAME);
+    joint_names.size = 3;
+
+    control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
+    joint_tolerances.size = 0;
+
+    //add a single JointTolerance
+    bzero(&joint_tolerance, sizeof(joint_tolerance));
+    control_msgs__msg__JointTolerance__init(&joint_tolerance);
+    rosidl_runtime_c__String__assign(&joint_tolerance.name, JOINT_NAME);
+    joint_tolerance.position = J0_POS_TOL;
+    joint_tolerance.velocity = 0.0;
+    joint_tolerance.acceleration = 0.0;
+    joint_tolerances.data[0] = joint_tolerance;
+    joint_tolerances.size = 1;
+
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
+
+    //call itself must succeed
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    //expect position tolerance for 'joint0' in first pos of output array
+    //NOTE: using equals, as position tolerance should have been directly copied
+    BOOL bT01 = posTolerances[JOINT0_IDX] == J0_POS_TOL;
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: j0 pos tol at [%d]: %s", __func__, JOINT0_IDX, bT01 ? "PASS" : "FAIL");
+
+    control_msgs__msg__JointTolerance__Sequence__fini(&joint_tolerances);
+    rosidl_runtime_c__String__Sequence__fini(&joint_names);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins()
+{
+    BOOL bSuccess = TRUE;
+
+    STATUS status = 0;
+    control_msgs__msg__JointTolerance joint_tolerance;
+    control_msgs__msg__JointTolerance__Sequence joint_tolerances;
+    rosidl_runtime_c__String__Sequence joint_names;
+    const size_t NUM_JOINTS = 3;
+    double posTolerances[NUM_JOINTS];
+    bzero(posTolerances, NUM_JOINTS);
+
+    rosidl_runtime_c__String__Sequence__init(&joint_names, NUM_JOINTS);
+    rosidl_runtime_c__String__assign(&joint_names.data[0], "joint0");
+    rosidl_runtime_c__String__assign(&joint_names.data[1], "joint2");
+    rosidl_runtime_c__String__assign(&joint_names.data[2], "joint1");
+    joint_names.size = 3;
+
+    control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
+    joint_tolerances.size = 0;
+
+    //JointTolerance for joint1
+    bzero(&joint_tolerance, sizeof(joint_tolerance));
+    control_msgs__msg__JointTolerance__init(&joint_tolerance);
+    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint1");
+    joint_tolerance.position = 0.123;
+    control_msgs__msg__JointTolerance__copy(&joint_tolerance, &joint_tolerances.data[0]);
+    joint_tolerances.size = 1;
+
+    //JointTolerance for joint2
+    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint2");
+    joint_tolerance.position = 0.234;
+    control_msgs__msg__JointTolerance__copy(&joint_tolerance, &joint_tolerances.data[1]);
+    joint_tolerances.size = 2;
+
+    //JointTolerance for joint1 -- NOTE: DUPLICATE
+    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint1");
+    joint_tolerance.position = 0.345;
+    control_msgs__msg__JointTolerance__copy(&joint_tolerance, &joint_tolerances.data[2]);
+    joint_tolerances.size = 3;
+
+    status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
+
+    //call itself must succeed
+    BOOL bT00 = status == OK;
+    bSuccess &= bT00;
+    Ros_Debug_BroadcastMsg("Testing %s: call: %s", __func__, bT00 ? "PASS" : "FAIL");
+
+    //check joint tols
+
+    //had no JointTolerance instance, so should be default
+    BOOL bT01 = posTolerances[0] == DEFAULT_FJT_GOAL_POSITION_TOLERANCE;
+    bSuccess &= bT01;
+    Ros_Debug_BroadcastMsg("Testing %s: j0 pos tol at [%d]: %s", __func__, 0, bT01 ? "PASS" : "FAIL");
+
+    //single JointTolerance instance
+    BOOL bT02 = posTolerances[1] == 0.234;
+    bSuccess &= bT02;
+    Ros_Debug_BroadcastMsg("Testing %s: j2 pos tol at [%d]: %s", __func__, 1, bT02 ? "PASS" : "FAIL");
+
+    //joint1 has two JointTolerances, last-setting wins, so should be == the last JointTolerance.position value
+    BOOL bT03 = posTolerances[2] == 0.345;
+    bSuccess &= bT03;
+    Ros_Debug_BroadcastMsg("Testing %s: j1 pos tol at [%d]: %s", __func__, 2, bT03 ? "PASS" : "FAIL");
+
+    control_msgs__msg__JointTolerance__Sequence__fini(&joint_tolerances);
+    rosidl_runtime_c__String__Sequence__fini(&joint_names);
+
+    Ros_Debug_BroadcastMsg("Testing %s: %s", __func__, bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_ActionServer_FJT()
+{
+    BOOL bSuccess = TRUE;
+
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_null_args();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_empty_jtolerances();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_too_small();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_than_jnames();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot0();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot2();
+    Ros_Debug_BroadcastMsg("~~~");
+    bSuccess &= Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins();
+    Ros_Debug_BroadcastMsg("~~~");
+
+    return bSuccess;
+}
+
+#endif //MOTOROS2_TESTING_ENABLE

--- a/src/Tests_ActionServer_FJT.c
+++ b/src/Tests_ActionServer_FJT.c
@@ -12,7 +12,7 @@
 #include <control_msgs/msg/joint_tolerance.h>
 
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_null_args()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_null_args()
 {
     BOOL bSuccess = TRUE;
 
@@ -46,7 +46,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_null_args()
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_empty_jtolerances()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_empty_jtolerances()
 {
     BOOL bSuccess = TRUE;
 
@@ -84,7 +84,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_empty_jtolerances(
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_too_small()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_too_small()
 {
     //output array of size == 1, two joints, single JointTolerance instance in goal.
     //success if 'output array too small' return value is returned
@@ -130,7 +130,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_too_smal
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_than_jnames()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_than_jnames()
 {
     //hypothetical controller with zero joints (so zero joint names, normal sized output array),
     //but goal with single JointTolerance instance.
@@ -185,7 +185,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_than_jna
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot0()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot0()
 {
     //hypothetical controller with single joint, goal with single JointTolerance instance.
     //success if JointTolerance position value == first element in output array.
@@ -239,7 +239,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot0()
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot2()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot2()
 {
     //hypothetical controller with single joint, goal with single JointTolerance instance.
     //success if JointTolerance position value == third element in output array.
@@ -296,7 +296,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slot2()
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins()
 {
     BOOL bSuccess = TRUE;
 
@@ -368,7 +368,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_setting_wins(
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_null_args()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_null_args()
 {
     BOOL bSuccess = TRUE;
 
@@ -411,7 +411,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_null_args
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_jnames_len_neq()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_jnames_len_neq()
 {
     BOOL bSuccess = TRUE;
 
@@ -449,7 +449,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_jnames_le
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_traj_pt_jnames_neq()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_traj_pt_jnames_neq()
 {
     //try to re-order values for a trajectory point which doesn't have a sufficient
     //nr of position values (at least not when compared to the nr of internal joint
@@ -505,7 +505,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_traj_pt_j
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_out_array_too_small()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_out_array_too_small()
 {
     //try to re-order values for a trajectory point while the output array is
     //too small.
@@ -558,7 +558,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_out_array
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_single_jt()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_single_jt()
 {
     //try to re-order values for a trajectory point for a single joint
 
@@ -609,7 +609,7 @@ BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_single_jt
     return bSuccess;
 }
 
-BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_6_jt_reorder()
+static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_6_jt_reorder()
 {
     BOOL bSuccess = TRUE;
 

--- a/src/Tests_ActionServer_FJT.h
+++ b/src/Tests_ActionServer_FJT.h
@@ -1,0 +1,17 @@
+// Tests_ActionServer_FJT.h
+
+// SPDX-FileCopyrightText: 2024, Yaskawa America, Inc.
+// SPDX-FileCopyrightText: 2024, Delft University of Technology
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MOTOROS2_TESTS_TESTS_ACTION_SERVER_FJT_H
+#define MOTOROS2_TESTS_TESTS_ACTION_SERVER_FJT_H
+
+#ifdef MOTOROS2_TESTING_ENABLE
+
+extern BOOL Ros_Testing_ActionServer_FJT();
+
+#endif //MOTOROS2_TESTING_ENABLE
+
+#endif  // MOTOROS2_TESTS_TESTS_ACTION_SERVER_FJT_H

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ void RosInitTask()
     bTestResult &= Ros_Testing_CtrlGroup();
     bTestResult &= Ros_Testing_RosMotoPlusConversionUtils();
     bTestResult &= Ros_Testing_ControllerStatusIO();
+    bTestResult &= Ros_Testing_ActionServer_FJT();
     bTestResult ? Ros_Debug_BroadcastMsg("Testing SUCCESSFUL") : Ros_Debug_BroadcastMsg("!!! Testing FAILED !!!");
     Ros_Debug_BroadcastMsg("===");
 #endif


### PR DESCRIPTION
This PR is to solve multiple issues dealing with goal tolerances referenced in #233 

1. Received Goal tolerances can now be received out of order, the name of the tolerance is used to match it with the expected joint.
2. The final goal position is used instead of the desired position to deal with a small out of sync issue.
3. The special notations of -1.0, to ignore tolerance, and 0.0, to use default values, is now supported.

This PR does not fix the issues with the Ros_Debug_BroadcastMsg function and doubles.

Testing:
[tolerance_issue_04162024.zip](https://github.com/Yaskawa-Global/motoros2/files/15001895/tolerance_issue_04162024.zip)

1. Upload the mr2_yrc1_h.out to the controller and then restart the controller
2. Run the microros client in a terminal : 
```sudo docker run -it --net=host -v /dev:/dev --privileged microros/micro-ros-agent:humble udp4 -p 8888```
3. Start the TrajMode:
```ros2 service call /start_traj_mode motoros2_interfaces/srv/StartTrajMode```
4. Run the fjt client:
```python3 fjt_client.py```
5. Optionally the debug_listener can also be ran to capture messages.

