### PR TITLE
ci: use more descriptive job names

### DIFF
--- a/.github/workflows/ci_check_subcode_docs.yaml
+++ b/.github/workflows/ci_check_subcode_docs.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  lint:
+  alarm_lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_md_lint.yaml
+++ b/.github/workflows/ci_md_lint.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  lint:
+  md_lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci_reuse_lint.yaml
+++ b/.github/workflows/ci_reuse_lint.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  test:
+  reuse_lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci_yamllint.yaml
+++ b/.github/workflows/ci_yamllint.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  lint:
+  yaml_lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As per title.

Makes it easier to discriminate between jobs in a listing.

With the current names it's just: `lint`, `lint`, `lint`, ...
