### PR TITLE
msbuild ci: bump version of `fetch-gh-release-asset`

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -78,7 +78,7 @@ jobs:
 
     - name: "Download M+ libmicroros (${{ matrix.ros2_codename }} on ${{ steps.uppercaser.outputs.ctrlr }})"
       id: download_libmicroros
-      uses: dsaltares/fetch-gh-release-asset@1.1.1
+      uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
         repo: 'yaskawa-global/motoros2'
         version: 'latest'


### PR DESCRIPTION
As per title.

Avoids `Node.js 16 actions are deprecated` warnings in the logs.
