### PR TITLE
ci: use GitHub CLI to download M+ libmicroros

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -87,17 +87,14 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: "Download M+ libmicroros (${{ matrix.uros.codename }}-${{ matrix.uros.release }} for ${{ steps.uppercaser.outputs.ctrlr }})"
-      id: download_libmicroros
-      uses: dsaltares/fetch-gh-release-asset@1.1.2
-      with:
-        repo: 'yaskawa-global/micro_ros_motoplus'
-        version: 'tags/release-${{ matrix.uros.codename }}-${{ matrix.controller }}-${{ matrix.uros.release }}'
-        regex: true
-        # download the M+ libmicroros distribution for the latest release of
-        # MotoROS2 corresponding to the controller this workflow is run for
-        file: "micro_ros_motoplus_${{ matrix.controller }}-${{ matrix.uros.codename }}.*\\.zip"
-        # work-around for https://github.com/dsaltares/fetch-gh-release-asset/issues/48
-        target: "./"
+      shell: bash
+      run: |
+        gh \
+          release \
+            --repo="yaskawa-global/micro_ros_motoplus" \
+          download \
+            --pattern="micro_ros_motoplus*.zip" \
+            release-${{ matrix.uros.codename }}-${{ matrix.controller }}-${{ matrix.uros.release }}
 
     - name: Setup MotoROS2 build dir
       shell: bash

--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -105,6 +105,7 @@ jobs:
             --repo="yaskawa-global/micro_ros_motoplus" \
           download \
             --pattern="micro_ros_motoplus*.zip" \
+            --output="micro_ros_motoplus.zip" \
             release-${{ matrix.uros.codename }}-${{ matrix.controller }}-${{ matrix.uros.release }}
 
     - name: Setup MotoROS2 build dir
@@ -116,25 +117,10 @@ jobs:
         cp -r "${{ github.workspace }}"/* /c/build/
         ls -al /c/build
 
-    - name: "Find downloaded M+ libmicroros (${{ matrix.uros.codename }}-${{ matrix.uros.release }} for ${{ steps.uppercaser.outputs.ctrlr }})"
-      id: find_libmicroros
-      shell: bash
-      # bit of a kludge, but works for now.
-      # we need to do this as 'fetch-gh-release-asset' will try to rename downloaded
-      # files if we use a regex to match 'unknown' files instead of hard-coding
-      # everything.
-      # NOTE: the regex includes the absolute path to the location of the .zip as that's
-      # how find reports them to the regex engine (because we specify an absolute path
-      # as the location for find to search for files)
-      run: |
-        LIBM_ZIP=$(find /c/build -type f -regextype posix-extended -regex "/c/build/micro_ros_motoplus_${{ matrix.controller }}-${{ matrix.uros.codename }}.*[[:digit:]]+\.zip")
-        echo "libmicroros_zip=${LIBM_ZIP}" >> $GITHUB_OUTPUT
-        echo "libmicroros_zip_win=$(cygpath -w ${LIBM_ZIP})" >> $GITHUB_OUTPUT
-        echo "Found libmicroros zip: '${LIBM_ZIP}'"
     - name: Extract M+ libmicroros distribution
       shell: bash
       run: |
-        unzip -q "${{ steps.find_libmicroros.outputs.libmicroros_zip }}" \
+        unzip -q /c/build/micro_ros_motoplus.zip \
           -d /c/build/motoros2/libmicroros_${{ matrix.controller }}_${{ matrix.uros.codename }}
 
     - name: Download and setup M+ SDK (mpBuilder)

--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -86,8 +86,19 @@ jobs:
     - name: Find MSBuild and add to PATH
       uses: microsoft/setup-msbuild@v2
 
+    - name: Generate token (micro_ros_motoplus)
+      id: gen_token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.MPLMB_APP_ID }}
+        private-key: ${{ secrets.MPLMB_APP_PRIVATE_KEY }}
+        owner: "yaskawa-global"
+        repositories: "micro_ros_motoplus"
+
     - name: "Download M+ libmicroros (${{ matrix.uros.codename }}-${{ matrix.uros.release }} for ${{ steps.uppercaser.outputs.ctrlr }})"
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ steps.gen_token.outputs.token }}
       run: |
         gh \
           release \


### PR DESCRIPTION
As per title.

This switches to the [GH CLI](https://cli.github.com/) for interaction with releases of `micro_ros_motoplus` from the currently used `dsaltares/fetch-gh-release-asset`.

This works just as well and also supports downloading assets from draft releases (which we'll need later).
