### PR TITLE
ci: support downloading `micro_ros_motoplus` prereleases

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -58,11 +58,7 @@ jobs:
       matrix:
         controller: [dx200, yrc1000, yrc1000u]
         # officially matrix doesn't support non-scalar values, but it does
-        # seem to work, so let's use it. We specify M+ uROS release distributions
-        # like this as it provides a (very) compact way to specify specific
-        # upstream releases. As not all controllers have all releases of all
-        # supported ROS 2 versions, this is less verbose than having to 'include'
-        # or 'exclude' certain entries from a regular full matrix spec (with lists).
+        # seem to work, so let's use it.
         uros: [
           { release: 20221102, codename: foxy     },
           { release: 20221102, codename: galactic },

--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -99,6 +99,7 @@ jobs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.gen_token.outputs.token }}
+        RELEASE_TYPE: ${{ (matrix.uros.prerelease && 'prerelease') || 'release' }}
       run: |
         gh \
           release \
@@ -106,7 +107,7 @@ jobs:
           download \
             --pattern="micro_ros_motoplus*.zip" \
             --output="micro_ros_motoplus.zip" \
-            release-${{ matrix.uros.codename }}-${{ matrix.controller }}-${{ matrix.uros.release }}
+            ${{ env.RELEASE_TYPE }}-${{ matrix.uros.codename }}-${{ matrix.controller }}-${{ matrix.uros.release }}
 
     - name: Setup MotoROS2 build dir
       shell: bash


### PR DESCRIPTION
As per title really.

Instead of just assuming / hard-coding `release` as the tag/release prefix, this allows adding a key called `prerelease` to the maps in `uros`. If that key is found, the rest of the workflow will assume it'll be downloading a *prerelease* `micro_ros_motoplus` archive.

This could be from an actually published prerelease, or a draft.

Example (and fictional) `matrix` entry:

```yaml
uros: [
  { release: 20221102, codename: foxy, prerelease: true },
  ...,
]
```
