### PR TITLE
Prevent building FJT tests stand-alone

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -864,4 +864,6 @@ void Ros_ActionServer_FJT_ProcessResult()
 
 
 //included here as this tests 'static' functions
+#define MOTOROS2_INCLUDE_TESTS_FJT_C
 #include "Tests_ActionServer_FJT.c"
+#undef MOTOROS2_INCLUDE_TESTS_FJT_C

--- a/src/Tests_ActionServer_FJT.c
+++ b/src/Tests_ActionServer_FJT.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-#ifdef MOTOROS2_TESTING_ENABLE
+#if defined(MOTOROS2_TESTING_ENABLE) && defined(MOTOROS2_INCLUDE_TESTS_FJT_C)
 
 #include "MotoROS.h"
 #include <control_msgs/msg/joint_tolerance.h>
@@ -714,4 +714,4 @@ BOOL Ros_Testing_ActionServer_FJT()
     return bSuccess;
 }
 
-#endif //MOTOROS2_TESTING_ENABLE
+#endif //#if defined(MOTOROS2_TESTING_ENABLE) && defined(MOTOROS2_INCLUDE_TESTS_FJT_C)


### PR DESCRIPTION
As per title.

Should fix #270 (well .. work around it).

See the commit message for additional comments.
