### PR TITLE
ci: complain about catch-alls documenting alarm (sub) codes

### DIFF
--- a/.ci/alarm_subcode_doc_linter.py
+++ b/.ci/alarm_subcode_doc_linter.py
@@ -132,7 +132,7 @@ def main():
         )
         if doc_range:
             if doc_range.is_catch_all and args.warn_catch_alls:
-                print(f"{sdef.loc_str}: warning: documented by catch-all '{doc_range}'")
+                print(f"{sdef.loc_str}: warning: '{sdef}' documented by catch-all '{doc_range}'")
         else:
             ret = 1
             print(f"{sdef.loc_str}: error: no documentation for '{sdef}' in '{args.md_file}'")

--- a/.github/workflows/ci_check_subcode_docs.yaml
+++ b/.github/workflows/ci_check_subcode_docs.yaml
@@ -27,6 +27,7 @@ jobs:
           python \
             .ci/alarm_subcode_doc_linter.py \
               --check-all \
+              --warn-catch-alls \
               --ignore-enum Failed_Trajectory_Status \
               --ignore-enum Init_Trajectory_Status \
               --ignore-enum MotionNotReadyCode \


### PR DESCRIPTION
This won't mark the job as failed, but it will result in annotations being added to a PR or CI run.

Example:

![image](https://github.com/user-attachments/assets/3da6c792-2636-40bf-bfb4-a4fd9c7f5983)

---

Edit: and on a PR we'd get:

![image](https://github.com/user-attachments/assets/8cb9b66b-2a73-411e-88dd-4da79dae3444)

But only the first 10 warnings.
