### PR TITLE
`0.1.3` release

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -60,9 +60,9 @@ jobs:
         # officially matrix doesn't support non-scalar values, but it does
         # seem to work, so let's use it.
         uros: [
-          { release: 20221102, codename: foxy     },
-          { release: 20221102, codename: galactic },
-          { release: 20221102, codename: humble   },
+          { release: 20240710, codename: foxy     },
+          { release: 20240710, codename: galactic },
+          { release: 20240710, codename: humble   },
         ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Changelog
 
-## Forthcoming
+## 0.1.3 (2024-08-01)
 
 MotoROS2 is now built against `micro_ros_motoplus` version `20240710`.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 [![license - Apache-2.0](https://img.shields.io/:license-Apache--2.0-yellowgreen.svg "MotoROS2 itself is licensed under the Apache-2.0 license. Please see the LICENSES directory for additional license files")](https://opensource.org/licenses/Apache-2.0)
 [![support level: consortium / vendor](https://img.shields.io/badge/support%20level-consortium%20/%20vendor-brightgreen.svg)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 
-![Version: 0.1.2](https://img.shields.io/badge/version-0.1.2-informational.svg)
+![Version: 0.1.3](https://img.shields.io/badge/version-0.1.3-informational.svg)
 
 ## Overview
 
@@ -117,7 +117,7 @@ Look for the version number starting with `DN`, `YAS` or `YBS`.
 
 ## Option Function compatibility
 
-The current version of MotoROS2 (`0.1.2`) is ***not*** compatible with the following Option Function(s) and/or other MotoPlus application(s):
+The current version of MotoROS2 (`0.1.3`) is ***not*** compatible with the following Option Function(s) and/or other MotoPlus application(s):
 
 - Simple Connect
 
@@ -161,7 +161,7 @@ To calculate the MD5 hash on Debian/Ubuntu for the main MotoROS2 binary, run the
 ```shell
 $ cd /path/to/where/the/binary/was/saved
 $ md5sum -b mr2_yrc1_h.out
-767c4f8ccc98eb4ee85146342c2984e7  mr2_yrc1_h.out
+e2d088b765a0bfed501aa213a1be1de0  mr2_yrc1_h.out
 ```
 
 Compare the output of `md5sum` when run against the binary downloaded in the previous section ([Downloading the files](#downloading-the-files)) with the values listed in the following table.
@@ -169,15 +169,15 @@ The values must match *exactly*.
 
 |**Controller** |**ROS 2 Version** | **File**          |**Version** | **MD5 hash**                       |
 |:--------------|:-----------------|:------------------|:-----------|:-----------------------------------|
-| DX200         | Foxy             | `mr2_dx2_f.out`   | `0.1.2`    | `9a8db7cd1ad436d6ace2cca8e0e2eb6b` |
-| DX200         | Galactic         | `mr2_dx2_g.out`   | `0.1.2`    | `d7e435ebf58c6b6da59555b941487af6` |
-| DX200         | Humble           | `mr2_dx2_h.out`   | `0.1.2`    | `95da6b0b93407855b8c133ece9a952be` |
-| YRC1000       | Foxy             | `mr2_yrc1_f.out`  | `0.1.2`    | `813e6ee6a72626bafffa54641d9b77f8` |
-| YRC1000       | Galactic         | `mr2_yrc1_g.out`  | `0.1.2`    | `41b249ef1132bce67284c41a68289e56` |
-| YRC1000       | Humble           | `mr2_yrc1_h.out`  | `0.1.2`    | `767c4f8ccc98eb4ee85146342c2984e7` |
-| YRC1000micro  | Foxy             | `mr2_yrc1m_f.out` | `0.1.2`    | `c1ca5fa9f44cf1e1e7de02174b3a6565` |
-| YRC1000micro  | Galactic         | `mr2_yrc1m_g.out` | `0.1.2`    | `20a6a332dc76bf657684a634b33c5c5e` |
-| YRC1000micro  | Humble           | `mr2_yrc1m_h.out` | `0.1.2`    | `22522443553457d5bd9ad08785d117ed` |
+| DX200         | Foxy             | `mr2_dx2_f.out`   | `0.1.3`    | `a9a9e10403f726062c25d97654fad316` |
+| DX200         | Galactic         | `mr2_dx2_g.out`   | `0.1.3`    | `e8db7512215da240b28b985f2f2af98b` |
+| DX200         | Humble           | `mr2_dx2_h.out`   | `0.1.3`    | `611bda537655cf8a60d85600da6043f4` |
+| YRC1000       | Foxy             | `mr2_yrc1_f.out`  | `0.1.3`    | `84bfb44e2043372127d9dfc1157a79b5` |
+| YRC1000       | Galactic         | `mr2_yrc1_g.out`  | `0.1.3`    | `866e090b6c724429ce03117712c951f4` |
+| YRC1000       | Humble           | `mr2_yrc1_h.out`  | `0.1.3`    | `e2d088b765a0bfed501aa213a1be1de0` |
+| YRC1000micro  | Foxy             | `mr2_yrc1m_f.out` | `0.1.3`    | `027e77b427a212aa63e5d7962d48ad92` |
+| YRC1000micro  | Galactic         | `mr2_yrc1m_g.out` | `0.1.3`    | `042d753a7729784fec8c5c23bef3e685` |
+| YRC1000micro  | Humble           | `mr2_yrc1m_h.out` | `0.1.3`    | `c0e61adbf5bf6fd6a734211f15bb0f0a` |
 
 If the hash matches, proceed with the next section, [Configuration](#configuration).
 

--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -9,7 +9,7 @@
 #define MOTOROS2_MOTOROS_H
 
 #define APPLICATION_NAME            "MotoROS2"
-#define APPLICATION_VERSION         "0.1.3pre"
+#define APPLICATION_VERSION         "0.1.3"
 
 #include "motoPlus.h"
 


### PR DESCRIPTION
Bumps MotoROS2 version to `0.1.3`, updates version references in the readme and the hashes for the new binaries.

I'll use a rebase merge and push a corresponding tag after review.
