### PR TITLE
Bump version to 0.1.4pre

### DIFF
--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -9,7 +9,7 @@
 #define MOTOROS2_MOTOROS_H
 
 #define APPLICATION_NAME            "MotoROS2"
-#define APPLICATION_VERSION         "0.1.3"
+#define APPLICATION_VERSION         "0.1.4pre"
 
 #include "motoPlus.h"
 


### PR DESCRIPTION
As per title.

Facilitate distinguishing between from-source builds and regular released binaries.
