### PR TITLE
reset_error: print correct char field, not struct

### DIFF
--- a/src/ServiceResetError.c
+++ b/src/ServiceResetError.c
@@ -123,5 +123,5 @@ void Ros_ServiceResetError_Trigger(const void* request_msg, void* response_msg)
     response->result_code.value = MOTION_READY;
 
 DONE:
-    Ros_Debug_BroadcastMsg("reset: %s", response->message);
+    Ros_Debug_BroadcastMsg("reset: %s", response->message.data);
 }


### PR DESCRIPTION
A `rosidl_runtime_c__String` is a `struct`, not a plain `char*`.

On some architectures/controller platforms it's OK to pass a pointer to the `struct` (apparently), as the first member is the `char*`, but at least on FS100 this doesn't work and results in garbage output to the debug log.
