### PR TITLE
Restructuring error reporting in start_traj_mode and start_point_queue_mode 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ libmicroros_dx200_foxy/
 
 # M+ build output
 *.out
+/libmicroros_yrc1000_iron

--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -252,7 +252,7 @@ rcl_ret_t Ros_ActionServer_FJT_Goal_Received(rclc_action_goal_handle_t* goal_han
         }
         else if (!bMotionReady)
         {
-            motomanErrorCode = Ros_Controller_GetNotReadySubcode();
+            motomanErrorCode = Ros_Controller_GetNotReadySubcode(false);
             rosidl_runtime_c__String__assign(&fjt_result_response.result.error_string,
                 Ros_ErrorHandling_MotionNotReadyCode_ToString((MotionNotReadyCode)motomanErrorCode));
         }

--- a/src/ControllerStatusIO.c
+++ b/src/ControllerStatusIO.c
@@ -441,7 +441,7 @@ MotionNotReadyCode Ros_Controller_GetNotReadySubcode()
     if(!Ros_Controller_IsPlay())
         return MOTION_NOT_READY_NOT_PLAY;
 
-    // Check if in continuous cycle mode (Here due to being checked before starting servor power)
+    // Check if in continuous cycle mode (Here due to being checked before starting servo power)
     if (!Ros_Controller_IsContinuousCycle())
         return MOTION_NOT_READY_NOT_CONT_CYCLE_MODE;
 

--- a/src/ControllerStatusIO.c
+++ b/src/ControllerStatusIO.c
@@ -383,7 +383,7 @@ BOOL Ros_Controller_IsMotionReady()
     BOOL bMotionReady;
 
 #ifndef DUMMY_SERVO_MODE
-    bMotionReady = Ros_Controller_GetNotReadySubcode() == MOTION_READY;
+    bMotionReady = Ros_Controller_GetNotReadySubcode(false) == MOTION_READY;
 #else
     bMotionReady = Ros_Controller_IsOperating();
 #endif
@@ -423,16 +423,8 @@ BOOL Ros_Controller_IsAnyFaultActive()
 }
 
 
-MotionNotReadyCode Ros_Controller_GetNotReadySubcode()
+MotionNotReadyCode Ros_Controller_GetNotReadySubcode(bool ignoreTractableProblems)
 {
-    // Check alarm
-    if(Ros_Controller_IsAlarm())
-        return MOTION_NOT_READY_ALARM;
-
-    // Check error
-    if(Ros_Controller_IsError())
-        return MOTION_NOT_READY_ERROR;
-
     // Check e-stop
     if(Ros_Controller_IsEStop())
         return MOTION_NOT_READY_ESTOP;
@@ -441,23 +433,19 @@ MotionNotReadyCode Ros_Controller_GetNotReadySubcode()
     if(!Ros_Controller_IsPlay())
         return MOTION_NOT_READY_NOT_PLAY;
 
-    // Check if in continuous cycle mode (Here due to being checked before starting servo power)
-    if (!Ros_Controller_IsContinuousCycle())
-        return MOTION_NOT_READY_NOT_CONT_CYCLE_MODE;
-
 #ifndef DUMMY_SERVO_MODE
     // Check remote
     if(!Ros_Controller_IsRemote())
         return MOTION_NOT_READY_NOT_REMOTE;
-
-    // Check servo power
-    if(!Ros_Controller_IsServoOn())
-        return MOTION_NOT_READY_SERVO_OFF;
 #endif
 
     // Check hold
     if(Ros_Controller_IsHold())
         return MOTION_NOT_READY_HOLD;
+
+    // Check alarm
+    if (Ros_Controller_IsAlarm())
+        return MOTION_NOT_READY_ALARM;
 
     // Check PFL active
     if (Ros_Controller_IsPflActive())
@@ -467,16 +455,34 @@ MotionNotReadyCode Ros_Controller_GetNotReadySubcode()
     if (Ros_Controller_IsMpIncMoveErrorActive())
         return MOTION_NOT_READY_INC_MOVE_ERROR;
 
-    // Check operating
-    if(!Ros_Controller_IsOperating())
-        return MOTION_NOT_READY_NOT_STARTED;
+    // Check error
+    if (Ros_Controller_IsError())
+        return MOTION_NOT_READY_ERROR;
 
-    if(!Ros_Controller_MasterTaskIsJobName(g_nodeConfigSettings.inform_job_name))
+    if (Ros_Controller_IsOperating() && !Ros_Controller_MasterTaskIsJobName(g_nodeConfigSettings.inform_job_name))
         return MOTION_NOT_READY_OTHER_PROGRAM_RUNNING;
 
-    // Check ready I/O signal (should confirm wait)
-    if(!Ros_Controller_IsWaitingRos())
-        return MOTION_NOT_READY_WAITING_ROS;
+    if (!ignoreTractableProblems)
+    {
+
+        // Check if in continuous cycle mode (Here due to being checked before starting servo power)
+        if (!Ros_Controller_IsContinuousCycle())
+            return MOTION_NOT_READY_NOT_CONT_CYCLE_MODE;
+#ifndef DUMMY_SERVO_MODE
+
+        // Check servo power
+        if (!Ros_Controller_IsServoOn())
+            return MOTION_NOT_READY_SERVO_OFF;
+#endif
+
+        // Check operating
+        if (!Ros_Controller_IsOperating())
+            return MOTION_NOT_READY_NOT_STARTED;
+
+        // Check ready I/O signal (should confirm wait)
+        if (!Ros_Controller_IsWaitingRos())
+            return MOTION_NOT_READY_WAITING_ROS;
+    }
 
     return MOTION_READY;
 }

--- a/src/ControllerStatusIO.h
+++ b/src/ControllerStatusIO.h
@@ -129,7 +129,7 @@ extern BOOL Ros_Controller_IsPflActive();
 extern BOOL Ros_Controller_IsMpIncMoveErrorActive();
 extern BOOL Ros_Controller_IsAnyFaultActive();
 extern BOOL Ros_Controller_MasterTaskIsJobName(const char* const jobName);
-extern MotionNotReadyCode Ros_Controller_GetNotReadySubcode(bool attemptingToStartMotion);
+extern MotionNotReadyCode Ros_Controller_GetNotReadySubcode(bool ignoreTractableProblems);
 
 //reset internal flag indicating whether PFL became active during a move
 extern void Ros_Controller_Reset_PflDuringRosMove();

--- a/src/ControllerStatusIO.h
+++ b/src/ControllerStatusIO.h
@@ -129,7 +129,7 @@ extern BOOL Ros_Controller_IsPflActive();
 extern BOOL Ros_Controller_IsMpIncMoveErrorActive();
 extern BOOL Ros_Controller_IsAnyFaultActive();
 extern BOOL Ros_Controller_MasterTaskIsJobName(const char* const jobName);
-extern MotionNotReadyCode Ros_Controller_GetNotReadySubcode();
+extern MotionNotReadyCode Ros_Controller_GetNotReadySubcode(bool attemptingToStartMotion);
 
 //reset internal flag indicating whether PFL became active during a move
 extern void Ros_Controller_Reset_PflDuringRosMove();

--- a/src/ErrorHandling.c
+++ b/src/ErrorHandling.c
@@ -28,6 +28,7 @@ const char* const Ros_ErrorHandling_ErrNo_ToString(int errNo)
     case 0x3050: return "Out of range (ABSO data)";
     case 0x3400: return "Cannot operate MASTER JOB";
     case 0x3410: return "The JOB name is already registered in another task";
+    case 0x3450: return "Servo power cannot be turned on";
     case 0x4040: return "Specified JOB not found";
     case 0x5200: return "Over data range";
     default:     return "Unspecified reason";
@@ -73,6 +74,10 @@ const char* const Ros_ErrorHandling_MotionNotReadyCode_ToString(MotionNotReadyCo
         return motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_NOT_CONT_CYCLE_MODE_STR;
     case MOTION_NOT_READY_MAJOR_ALARM:
         return motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_MAJOR_ALARM_STR;
+    case MOTION_NOT_READY_ECO_MODE:
+        return motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_ECO_MODE_STR;
+    case MOTION_NOT_READY_SERVO_ON_TIMEOUT:
+        return motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_SERVO_ON_TIMEOUT_STR;
     default:
         return motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_UNSPECIFIED_STR;
     }

--- a/src/ErrorHandling.h
+++ b/src/ErrorHandling.h
@@ -33,6 +33,8 @@ typedef enum
     MOTION_NOT_READY_OTHER_TRAJ_MODE_ACTIVE = motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_OTHER_TRAJ_MODE_ACTIVE,
     MOTION_NOT_READY_NOT_CONT_CYCLE_MODE = motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_NOT_CONT_CYCLE_MODE,
     MOTION_NOT_READY_MAJOR_ALARM = motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_MAJOR_ALARM,
+    MOTION_NOT_READY_ECO_MODE = motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_ECO_MODE,
+    MOTION_NOT_READY_SERVO_ON_TIMEOUT = motoros2_interfaces__msg__MotionReadyEnum__NOT_READY_SERVO_ON_TIMEOUT,
 } MotionNotReadyCode;
 
 typedef enum

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1392,7 +1392,10 @@ MotionNotReadyCode Ros_MotionControl_StartMotionMode(MOTION_MODE mode, rosidl_ru
         case MOTION_NOT_READY_NOT_REMOTE:
         case MOTION_NOT_READY_HOLD:
             return motion_readiness_code;
-        case MOTION_NOT_READY_ERROR:
+        case MOTION_NOT_READY_ERROR: 
+            //the responseMessage gets populated only in this case or for other MOTION_NOT_READY_ERROR
+            //returns because it has the most information about the error in this situtation. 
+            //in other cases, the responseMessage is populated upstream/with only the MotionNotReadyCode
             alarmcode = Ros_Controller_GetAlarmCode();
             snprintf(output, MOTION_START_ERROR_MESSAGE_LENGTH, "%s: '%s' (0x%04X)",
                 Ros_ErrorHandling_MotionNotReadyCode_ToString(MOTION_NOT_READY_ERROR),

--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -12,6 +12,7 @@
 
 #define MOTION_START_TIMEOUT                5000  // in milliseconds
 #define MOTION_START_CHECK_PERIOD           50  // in millisecond
+#define MOTION_START_ERROR_MESSSAGE_LENGTH  256
 #define MOTION_STOP_TIMEOUT                 20
 
 typedef enum

--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -12,7 +12,7 @@
 
 #define MOTION_START_TIMEOUT                5000  // in milliseconds
 #define MOTION_START_CHECK_PERIOD           50  // in millisecond
-#define MOTION_START_ERROR_MESSSAGE_LENGTH  256
+#define MOTION_START_ERROR_MESSAGE_LENGTH  256
 #define MOTION_STOP_TIMEOUT                 20
 
 typedef enum

--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -32,7 +32,7 @@ extern BOOL Ros_MotionControl_IsRosControllingMotion();
 extern int Ros_MotionControl_GetQueueCnt(int groupNo);
 extern BOOL Ros_MotionControl_StopMotion(BOOL bKeepJobRunning);
 extern BOOL Ros_MotionControl_ClearQ_All();
-extern BOOL Ros_MotionControl_StartMotionMode(MOTION_MODE mode);
+extern MotionNotReadyCode Ros_MotionControl_StartMotionMode(MOTION_MODE mode, rosidl_runtime_c__String* responseMessage);
 extern void Ros_MotionControl_StopTrajMode();
 
 extern BOOL Ros_MotionControl_IsMotionMode_Trajectory();

--- a/src/ServiceStartPointQueueMode.c
+++ b/src/ServiceStartPointQueueMode.c
@@ -53,21 +53,14 @@ void Ros_ServiceStartPointQueueMode_Trigger(const void* request_msg, void* respo
     response->result_code.value = MOTION_READY;
     rosidl_runtime_c__String__assign(&response->message, "");
     
-    if (!Ros_MotionControl_StartMotionMode(MOTION_MODE_POINTQUEUE))
+    MotionNotReadyCode motion_result_code = Ros_MotionControl_StartMotionMode(MOTION_MODE_POINTQUEUE, &response->message);
+    if (motion_result_code != MOTION_READY)
     {
         // update response
-        response->result_code.value = Ros_Controller_GetNotReadySubcode();
+        response->result_code.value = motion_result_code;
 
-        if (response->result_code.value == MOTION_READY || Ros_MotionControl_IsMotionMode_Trajectory() || Ros_MotionControl_IsMotionMode_RawStreaming())
-        {
-            //Motion is ready, but the StartPointQueueMode service failed
-            //because it's already in a different mode.
-            response->result_code.value = MOTION_NOT_READY_OTHER_TRAJ_MODE_ACTIVE;
-            rosidl_runtime_c__String__assign(&response->message,
-                "Another motion mode is already active. Please call 'stop_traj_mode' service and try again.");
-        }
-        else
-        {
+        //If it is a MOTION_NOT_READY_ERROR, then the string was already populated in the Ros_MotionControl_StartMotionMode function
+        if (motion_result_code != MOTION_NOT_READY_ERROR) {
             // map to human readable string
             rosidl_runtime_c__String__assign(&response->message,
                 Ros_ErrorHandling_MotionNotReadyCode_ToString((MotionNotReadyCode)response->result_code.value));

--- a/src/ServiceStartTrajMode.c
+++ b/src/ServiceStartTrajMode.c
@@ -53,21 +53,14 @@ void Ros_ServiceStartTrajMode_Trigger(const void* request_msg, void* response_ms
     response->result_code.value = MOTION_READY;
     rosidl_runtime_c__String__assign(&response->message, "");
     
-    if (!Ros_MotionControl_StartMotionMode(MOTION_MODE_TRAJECTORY))
+    MotionNotReadyCode motion_result_code = Ros_MotionControl_StartMotionMode(MOTION_MODE_TRAJECTORY, &response->message);
+    if (motion_result_code != MOTION_READY)
     {
         // update response
-        response->result_code.value = Ros_Controller_GetNotReadySubcode();
+        response->result_code.value = motion_result_code;
 
-        if (response->result_code.value == MOTION_READY || Ros_MotionControl_IsMotionMode_PointQueue() || Ros_MotionControl_IsMotionMode_RawStreaming())
-        {
-            //Motion is ready, but the StartTrajMode service failed
-            //because it's already in a different mode.
-            response->result_code.value = MOTION_NOT_READY_OTHER_TRAJ_MODE_ACTIVE;
-            rosidl_runtime_c__String__assign(&response->message,
-                "Another motion mode is already active. Please call 'stop_traj_mode' service and try again.");
-        }
-        else
-        {
+        //If it is a MOTION_NOT_READY_ERROR, then the string was already populated in the Ros_MotionControl_StartMotionMode function
+        if (motion_result_code != MOTION_NOT_READY_ERROR) {
             // map to human readable string
             rosidl_runtime_c__String__assign(&response->message,
                 Ros_ErrorHandling_MotionNotReadyCode_ToString((MotionNotReadyCode)response->result_code.value));


### PR DESCRIPTION
Changes start_traj_mode and start_point_queue_mode services so that they properly report the reasons for failure in case motion cannot be started. This addresses many of the concerns brought up in the discussion of PR #265. I closed that PR and opened this to simplify bringing it up to date with main and to make the history less confusing. 