### PR TITLE
Allow the user to insert USB with config file after bootup

### DIFF
--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -767,14 +767,14 @@ void Ros_ConfigFile_Parse()
 
     Ros_ConfigFile_SetAllDefaultValues();
 
-#if defined (YRC1000) || defined (YRC1000u)
-    //config file always resides on USB for DX200/FS100, so only check
-    //on YRC1000 and micro
-    Ros_ConfigFile_CheckUsbForNewConfigFile();
-#endif
-
     do
     {
+#if defined (FS100) ||defined (YRC1000) || defined (YRC1000u)
+        //config file always resides on USB for DX200, so only check
+        //on YRC1000 and micro
+        Ros_ConfigFile_CheckUsbForNewConfigFile();
+#endif
+
         if (!bOkToInit)
             Ros_Sleep(3000);
 


### PR DESCRIPTION
While testing #277, I inserted the USB after bootup. It didn't recognize my config file until I rebooted.