### PR TITLE
Fix condition so tool number 63 can be selected properly

### DIFF
--- a/src/ServiceSelectMotionTool.c
+++ b/src/ServiceSelectMotionTool.c
@@ -83,7 +83,7 @@ void Ros_ServiceSelectMotionTool_Trigger(const void* request_msg, void* response
     }
 
     //make sure a valid tool is specified (tool_number is unsigned, so cannot be < 0)
-    if (request->tool_number >= MAX_VALID_TOOL_INDEX)
+    if (request->tool_number > MAX_VALID_TOOL_INDEX)
     {
         rosidl_runtime_c__String__assign(&response->message, motoros2_interfaces__msg__SelectionResultCodes__INVALID_SELECTION_INDEX_STR);
         response->result_code.value = motoros2_interfaces__msg__SelectionResultCodes__INVALID_SELECTION_INDEX;


### PR DESCRIPTION
Right now tool 63 cannot be selected because this condition evaluates as true and exits the function. With this change, tool 63 should be selectable. 