### PR TITLE
YRC1000u LAN Port Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,8 @@ The following general requirements must be met in order to be able to use MotoRO
   - `YAS2.80.00-00` for YRC1000
   - `YBS2.45.00-00` for YRC1000micro
 - the controller must have a correctly configured network connection:
-  - DX200: `LAN`
+  - DX200 and YRC1000micro: `LAN`
   - YRC1000: either `LAN2` or `LAN3`
-  - YRC1000micro: either `LAN2` or `LAN3`
 - ROS 2 version: Foxy, Galactic or Humble.
   MotoROS2 does not support ROS 2 Iron Irwini, nor Jazzy nor Rolling Ridley.
 - Docker or a from-source build of the micro-ROS Agent

--- a/config/motoros2_config.yaml
+++ b/config/motoros2_config.yaml
@@ -102,8 +102,8 @@ sync_timeclock_with_agent: true
 # To disable auto-detection, uncomment 'userlan_monitor_port' below and set
 # it to the desired port.
 #
-# NOTE:   this setting only applies to YRC1000 and YRC1000u controllers.
-#         DX200 and FS100 controllers only have a single ethernet port, and any
+# NOTE:   this setting only applies to YRC1000 controllers. YRC1000u, DX200,
+#         and FS100 controllers only have a single ethernet port, and any
 #         value other than 1 will be ignored.
 #
 # NOTE 2: auto-detection is not perfect. It can't determine whether the Agent
@@ -309,9 +309,9 @@ publisher_qos:
 # To choose a specific port to broadcast debug messages, uncomment
 # 'debug_broadcast_port' below and set it to the desired port.
 #
-# NOTE 1:   this setting only applies to YRC1000 and YRC1000u controllers.
-#         DX200 and FS100 controllers only have a single ethernet port, and will
-#         always default to USER_LAN1
+# NOTE 1:   this setting only applies to YRC1000 controllers. YRC1000u,
+#         DX200, and FS100 controllers only have a single ethernet port,
+#         and will always default to USER_LAN1
 #
 # OPTIONS: USER_LAN1, USER_LAN2
 # DEFAULT: (all available network ports)

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -947,7 +947,7 @@ ALARM 8013
 The `userlan_monitor_port` key in the `motoros2_config.yaml` configuration file is set to an invalid value.
 LAN port monitoring will be disabled for this session.
 
-On YRC1000 and YRC1000u, this must be set to either `USER_LAN1` or `USER_LAN2`.
+On YRC1000, this must be set to either `USER_LAN1` or `USER_LAN2`.
 
 No other values are supported.
 
@@ -973,7 +973,7 @@ To rule out a transient failure, reboot the controller.
 
 If the alarm is raised again, and if auto-detection is not needed or desired, make sure `userlan_monitor_port` is not commented out (ie: does not have a `#` at the start of the line) and set it to an appropriate value.
 
-On YRC1000 and YRC1000u, set it to either `USER_LAN1` or `USER_LAN2`, depending on which LAN port is used to connect the controller to the PC running the micro-ROS Agent application.
+On YRC1000, set it to either `USER_LAN1` or `USER_LAN2`, depending on which LAN port is used to connect the controller to the PC running the micro-ROS Agent application.
 
 If auto-detection is to be used, verify `agent_ip_address` is set to an IP that can be reached by MotoROS2 over the LAN port which is connected to the PC running the micro-ROS Agent application (either directly, or via a default gateway configured on the controller).
 
@@ -1053,7 +1053,7 @@ ALARM 8013
 The `debug_broadcast_port` key in the `motoros2_config.yaml` configuration file is set to an invalid value.
 Debug messages will be sent over all active network ports
 
-On YRC1000 and YRC1000u, this must be set to either `USER_LAN1` or `USER_LAN2`.
+On YRC1000, this must be set to either `USER_LAN1` or `USER_LAN2`.
 
 No other values are supported.
 

--- a/src/CommunicationExecutor.c
+++ b/src/CommunicationExecutor.c
@@ -74,7 +74,7 @@ void Ros_Communication_ConnectToAgent()
             "Must enable ETHERNET function");
     }
 
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000)
     //Try second interface if first one didn't succeed
     if (status != OK && (status = Ros_GetMacAddress(ROS_USER_LAN2, macId)) != OK)
     {

--- a/src/ConfigFile.c
+++ b/src/ConfigFile.c
@@ -151,7 +151,7 @@ void Ros_ConfigFile_SetAllDefaultValues()
             "Must enable ETHERNET function");
     }
 
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000)
     //Try second interface if first one didn't succeed
     if (status != OK && (status = Ros_GetMacAddress(ROS_USER_LAN2, macId)) != OK)
     {
@@ -331,12 +331,12 @@ void Ros_ConfigFile_CheckYamlEvent(yaml_event_t* event)
                     break;
 
                 case Value_UserLanPort:
-#if defined (FS100) || defined (DX200)
+#if defined (FS100) || defined (DX200) || defined (YRC1000u)
                     // single port, override whatever was configured
                     * (Ros_UserLan_Port_Setting*)activeItem->valueToSet = CFG_ROS_USER_LAN1;
-                    Ros_Debug_BroadcastMsg("DX200 or FS100: override to 'USER_LAN1'");
+                    Ros_Debug_BroadcastMsg("DX200, YRC1000u, or FS100: override to 'USER_LAN1'");
 
-#elif defined (YRC1000) || defined (YRC1000u)
+#elif defined (YRC1000)
                     if (strncmp((char*)event->data.scalar.value, "USER_LAN1", 9) == 0)
                         *(Ros_UserLan_Port_Setting*)activeItem->valueToSet = CFG_ROS_USER_LAN1;
                     else if (strncmp((char*)event->data.scalar.value, "USER_LAN2", 9) == 0)
@@ -557,7 +557,7 @@ void Ros_ConfigFile_ValidateCriticalSettings()
     motoRosAssert_withMsg(status == OK, SUBCODE_CONFIGURATION_AGENT_ON_NET_CHECK,
         "Host on NIC check 1");
 
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000)
     if (!bAgentOnMySubnet)
     {
         //check second lan port
@@ -652,7 +652,7 @@ void Ros_ConfigFile_ValidateNonCriticalSettings()
             }
         }
 
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000)
         //on these controllers we can try the second interface, if we haven't
         //already determined we should monitor the first
         if (g_nodeConfigSettings.userlan_monitor_port == CFG_ROS_USER_LAN_AUTO)
@@ -688,11 +688,11 @@ void Ros_ConfigFile_ValidateNonCriticalSettings()
         //In both cases, verify it's an acceptable value.
         else
         {
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000)
             if (g_nodeConfigSettings.userlan_monitor_port != CFG_ROS_USER_LAN1 &&
                 g_nodeConfigSettings.userlan_monitor_port != CFG_ROS_USER_LAN2)
 
-#elif defined (FS100) || defined (DX200)
+#elif defined (FS100) || defined (DX200)  || defined (YRC1000u)
             if (g_nodeConfigSettings.userlan_monitor_port != CFG_ROS_USER_LAN1)
 #endif
             {
@@ -710,11 +710,11 @@ void Ros_ConfigFile_ValidateNonCriticalSettings()
     {
         Ros_Debug_BroadcastMsg("UserLan debug broadcast enabled, checking port setting...");
         //Check if the port setting is valid only if the debug broadcast is enabled
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000)
         if (g_nodeConfigSettings.debug_broadcast_port != CFG_ROS_USER_LAN1 &&
             g_nodeConfigSettings.debug_broadcast_port != CFG_ROS_USER_LAN2 && 
             g_nodeConfigSettings.debug_broadcast_port != CFG_ROS_USER_LAN_ALL)
-#elif defined (FS100) || defined (DX200)
+#elif defined (FS100) || defined (DX200)  || defined (YRC1000u)
         if (g_nodeConfigSettings.debug_broadcast_port != CFG_ROS_USER_LAN1)
 #endif
         {
@@ -890,7 +890,7 @@ void Ros_ConfigFile_Parse()
 
     Ros_ConfigFile_ValidateCriticalSettings();
     Ros_ConfigFile_ValidateNonCriticalSettings();
-#if defined(YRC1000) || defined(YRC1000u)
+#if defined(YRC1000)
     // If the debug broadcast is enabled and the user chose a specific port, then 
     // we can no longer broadcast over ALL, we have to change it to only broadcast over one port
     if (g_nodeConfigSettings.debug_broadcast_enabled &&

--- a/src/ConfigFile.h
+++ b/src/ConfigFile.h
@@ -101,7 +101,12 @@ typedef enum
 #define DEFAULT_IGNORE_MISSING_CALIB            FALSE
 
 #define DEFAULT_ULAN_DEBUG_BROADCAST_ENABLED     TRUE
+
+#if defined (YRC1000)
 #define DEFAULT_ULAN_DEBUG_BROADCAST_PORT        CFG_ROS_USER_LAN_ALL
+#else
+#define DEFAULT_ULAN_DEBUG_BROADCAST_PORT        CFG_ROS_USER_LAN1
+#endif
 typedef struct
 {
     //TODO(gavanderhoorn): add support for unsigned types

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -7,7 +7,7 @@
 
 #ifndef MOTOROS2_DEBUG_H
 #define MOTOROS2_DEBUG_H
-#if defined (YRC1000) || defined (YRC1000u)
+#if defined (YRC1000) 
 #define MAX_NETWORK_PORTS 2
 #else
 #define MAX_NETWORK_PORTS 1


### PR DESCRIPTION
For #310. This removes references to the second LAN port on the YRC1000u. It also fixes a bug where controllers with only 1 LAN port will alarm unnecessarily if no debug port is specifically configured. I tested this on a YRC1000u. 