### PR TITLE
Partial memory leak fix

### DIFF
--- a/src/ServiceQueueTrajPoint.c
+++ b/src/ServiceQueueTrajPoint.c
@@ -46,7 +46,6 @@ void Ros_ServiceQueueTrajPoint_Initialize()
     
     //--------------
     g_messages_QueueTrajPoint.response = motoros2_interfaces__srv__QueueTrajPoint_Response__create();
-    rosidl_runtime_c__String__init(&g_messages_QueueTrajPoint.response->message);
 
     //--------------
     MOTOROS2_MEM_TRACE_REPORT(svc_queue_point_init);

--- a/src/main.c
+++ b/src/main.c
@@ -144,8 +144,7 @@ void RosInitTask()
         if (tid == ERROR)
             mpSetAlarm(ALARM_TASK_CREATE_FAIL, APPLICATION_NAME " FAILED TO CREATE TASK", SUBCODE_EXECUTOR);
 
-        Ros_Debug_BroadcastMsg("Initialization complete. Memory available: (%d) bytes. Memory in use: (%d) bytes",
-                       mpNumBytesFree(), MP_MEM_PART_SIZE - mpNumBytesFree());
+        Ros_Debug_BroadcastMsg("Initialization complete.");
 
         //==================================
         ULONG tickBefore = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -105,6 +105,7 @@ void RosInitTask()
     //==================================
     FOREVER
     {
+        MOTOROS2_MEM_TRACE_START(full_connection_cycle);
         Ros_Controller_StatusInit();
 
         Ros_Allocation_Initialize(&g_motoros2_Allocator);
@@ -224,6 +225,7 @@ void RosInitTask()
         Ros_Sleep(2500);
 
         Ros_Debug_BroadcastMsg("Shutdown complete. Available memory: (%d) bytes", mpNumBytesFree());
+        MOTOROS2_MEM_TRACE_REPORT(full_connection_cycle);
     }
 }
 


### PR DESCRIPTION
A partial fix for #35. 

There was a member of the QueueTrajPoint response that was getting initialized twice.
```
g_messages_QueueTrajPoint.response = motoros2_interfaces__srv__QueueTrajPoint_Response__create();
rosidl_runtime_c__String__init(&g_messages_QueueTrajPoint.response->message);
```
The response creation call already initialized `g_messages_QueueTrajPoint.response->message`, so the init call that followed caused a memory leak. 

This will not close out the issue, as there is still a trickier memory leak as mentioned [in this comment](https://github.com/Yaskawa-Global/motoros2/issues/35#issuecomment-2474370293). But from my testing, this does seem to recoup somewhere in the range of 24-48 bytes each connect/disconnect cycle. 