### PR TITLE
Add note about `mpGetFBPulsePosEx`

### DIFF
--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -336,6 +336,13 @@ BOOL Ros_CtrlGroup_GetFBPulsePos(CtrlGroup* ctrlGroup, long pulsePos[MAX_PULSE_A
 #ifndef DUMMY_SERVO_MODE
     // get raw (uncorrected/unscaled) joint positions
     LONG status = mpGetFBPulsePos (&sData,&pulse_data);
+
+    //TODO: Consider using mpGetFBPulsePosEx. The `ex` version automatically applies
+    //      any needed corrections, such as gravity compensation and cross-axis
+    //      coupling. We're already (manually) applying those corrections, so we don't
+    //      need the `ex` version. But if the next controller generation adds some new
+    //      feature, then we should transition so that we don't have to worry about it.
+
     if (0 != status)
     {
         Ros_Debug_BroadcastMsg("Failed to get pulse feedback position: %u", status);

--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -342,6 +342,7 @@ BOOL Ros_CtrlGroup_GetFBPulsePos(CtrlGroup* ctrlGroup, long pulsePos[MAX_PULSE_A
     //      coupling. We're already (manually) applying those corrections, so we don't
     //      need the `ex` version. But if the next controller generation adds some new
     //      feature, then we should transition so that we don't have to worry about it.
+    //      See also yaskawa-global/motoros2#199.
 
     if (0 != status)
     {


### PR DESCRIPTION
Clarify about why we may want to consider it for future usage.

In response to https://github.com/Yaskawa-Global/motoros2/issues/199#issuecomment-2498879600