### PR TITLE
Change default joint_state names for single-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,12 +641,12 @@ follow_joint_trajectory:
   type: FollowJointTrajectory
   default: true
   joints:
-   - group_1/joint_1
-   - group_1/joint_2
-   - group_1/joint_3
-   - group_1/joint_4
-   - group_1/joint_5
-   - group_1/joint_6
+   - joint_1
+   - joint_2
+   - joint_3
+   - joint_4
+   - joint_5
+   - joint_6
 
 ...
 ```

--- a/config/motoros2_config.yaml
+++ b/config/motoros2_config.yaml
@@ -177,9 +177,11 @@ namespace_tf: true
 # When using a 7 axis robot arm with an elbow joint (E) in the middle of the
 # arm, the elbow axis should be listed last (SLURBTE).
 #
-# DEFAULT: "group_x/joint_y"
+# DEFAULT:
+# - Single-group: "joint_y"
+# - Multi-group: "group_x/joint_y"
 #joint_names:
-#- [group_1/joint_1, group_1/joint_2, group_1/joint_3, group_1/joint_4, group_1/joint_5, group_1/joint_6]
+#- [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]
 
 #-----------------------------------------------------------------------------
 # Logging settings

--- a/config/motoros2_config.yaml
+++ b/config/motoros2_config.yaml
@@ -178,8 +178,8 @@ namespace_tf: true
 # arm, the elbow axis should be listed last (SLURBTE).
 #
 # DEFAULT:
-# - Single-group: "joint_y"
-# - Multi-group: "group_x/joint_y"
+# - Single-group: "joint_M"
+# - Multi-group: "group_N/joint_M"
 #joint_names:
 #- [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -135,7 +135,7 @@ Refer to [No support for asynchronous motion](../README.md#no-support-for-asynch
 
 ## Can names of joints be changed?
 
-The names used by MotoROS2 for joints (in `JointState` messages for instance) by default follow a generic naming scheme: `group_N/joint_M` (with `N` and `M` ∈ ℕ⁺: 1, 2, 3, 4, ...).
+The names used by MotoROS2 for joints (in `JointState` messages for instance) by default follow the naming scheme `joint_M` for single-group and `group_N/joint_M` for multi-group (with `N` and `M` ∈ ℕ⁺: 1, 2, 3, 4, ...).
 
 Custom joint names can be configured through the configuration file, specifically the `joint_names` key.
 This key is a list-of-lists, with each top-level list corresponding to a group, and each entry inside each list corresponding to the joint in that group.

--- a/src/ConfigFile.h
+++ b/src/ConfigFile.h
@@ -33,7 +33,8 @@
 
 // NOTE: We do not prefix joints by the "motoman Grp ID" here, but use the generic
 // group & joint names instead to avoid the OEM-specific names.
-#define DEFAULT_JOINT_NAME_FMT          "group_%d/joint_%d"
+#define DEFAULT_JOINT_NAME_FMT_SINGLE  "joint_%d"
+#define DEFAULT_JOINT_NAME_FMT_MULTI   "group_%d/joint_%d"
 
 #define DEFAULT_LOG_TO_STDOUT           FALSE
 

--- a/src/ControllerStatusIO.c
+++ b/src/ControllerStatusIO.c
@@ -99,7 +99,14 @@ BOOL Ros_Controller_Initialize()
                 {
                     for (int jointIndex = 0; jointIndex < g_Ros_Controller.ctrlGroups[groupIndex]->numAxes; jointIndex += 1)
                     {
-                        sprintf(g_nodeConfigSettings.joint_names[(groupIndex * MP_GRP_AXES_NUM) + jointIndex], DEFAULT_JOINT_NAME_FMT, groupIndex + 1, jointIndex + 1);
+                        if (g_Ros_Controller.numGroup == 1)
+                        {
+                            sprintf(g_nodeConfigSettings.joint_names[(groupIndex * MP_GRP_AXES_NUM) + jointIndex], DEFAULT_JOINT_NAME_FMT_SINGLE, jointIndex + 1);
+                        }
+                        else
+                        {
+                            sprintf(g_nodeConfigSettings.joint_names[(groupIndex * MP_GRP_AXES_NUM) + jointIndex], DEFAULT_JOINT_NAME_FMT_MULTI, groupIndex + 1, jointIndex + 1);
+                        }
                     }
                 }
 


### PR DESCRIPTION
As discussed in https://github.com/Yaskawa-Global/motoros2/discussions/331. Omit the "group_N" part of the message if it is a single group. 