### PR TITLE
Forward Init_Trajectory_Status error message to queue_traj_point

### DIFF
--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -607,7 +607,7 @@ BOOL Ros_MotionControl_AddPulseIncPointToQ(CtrlGroup* ctrlGroup, Incremental_dat
     return TRUE;
 }
 
-UINT8 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__QueueTrajPoint_Request* request)
+UINT16 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__QueueTrajPoint_Request* request)
 {
     if (Ros_MotionControl_MustInitializePointQueue)
     {
@@ -617,9 +617,13 @@ UINT8 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__Q
         status = Ros_MotionControl_InitPointQueue(request);
 
         if (status == INIT_TRAJ_OK)
+        {
             return motoros2_interfaces__msg__QueueResultEnum__SUCCESS;
+        }
         else
-            return motoros2_interfaces__msg__QueueResultEnum__INIT_FAILURE;
+        {
+            return status;
+        }
     }
 
     //------------------------------------------------------------

--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -25,7 +25,7 @@ typedef enum
 extern Init_Trajectory_Status Ros_MotionControl_InitTrajectory(control_msgs__action__FollowJointTrajectory_SendGoal_Request* pending_ros_goal_request);
 extern void Ros_MotionControl_IncMoveLoopStart();
 extern void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup);
-extern UINT8 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__QueueTrajPoint_Request* request);
+extern UINT16 Ros_MotionControl_ProcessQueuedTrajectoryPoint(motoros2_interfaces__srv__QueueTrajPoint_Request* request);
 extern BOOL Ros_MotionControl_AddPulseIncPointToQ(CtrlGroup* ctrlGroup, Incremental_data const* dataToEnQ);
 extern BOOL Ros_MotionControl_HasDataInQueue();
 extern BOOL Ros_MotionControl_HasDataToProcess();


### PR DESCRIPTION
#336 

All FAILURE error codes/messages from Ros_MotionControl_InitPointQueue (and further Ros_MotionControl_Init) previously got squashed into success/failure. This commit maintains the error meaning