### PR TITLE
Fix FJT goal tolerance violated message

### DIFF
--- a/src/ActionServer_FJT.c
+++ b/src/ActionServer_FJT.c
@@ -703,7 +703,7 @@ goal_complete_skip_tolerance_comparison: ;
                     if (violators[axis])
                     {
                         char formatBuffer[64] = { 0 };
-                        snprintf(formatBuffer, 64, " [%s: %d deviation]",
+                        snprintf(formatBuffer, 64, " [%s: %.5f deviation]",
                             feedback_FollowJointTrajectory.feedback.joint_names.data[axis].data,
                             violators[axis]);
                         strcat(msgBuffer, formatBuffer);


### PR DESCRIPTION
#343 

Right now the message is printing out the "violation" (deviation amount) as an integer despite the fact that the array is made up of doubles. This just changes the format specifier to print a floating point value instead.