### PR TITLE
ci: bump M+ libmicroros version

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -60,9 +60,9 @@ jobs:
         # officially matrix doesn't support non-scalar values, but it does
         # seem to work, so let's use it.
         uros: [
-          { release: 20240917, codename: foxy     },
-          { release: 20240917, codename: galactic },
-          { release: 20240917, codename: humble   },
+          { release: 20241211, codename: foxy     },
+          { release: 20241211, codename: galactic },
+          { release: 20241211, codename: humble   },
         ]
 
     steps:


### PR DESCRIPTION
As per title.

Should fix CI.

---

Edit: test run: https://github.com/Yaskawa-Global/motoros2/actions/runs/12735310867 (I should really fix CI to not skip the `msbuild` job if the workflow itself gets edited).
