### PR TITLE
Fix stop_traj_mode errors

### DIFF
--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -360,14 +360,8 @@ void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup)
         if (Ros_MotionControl_AllGroupsInitComplete)
         {
             // if there is no message to process, delay and try again
-            if (ctrlGroup->hasDataToProcess && ctrlGroup->trajectoryIterator != NULL && ctrlGroup->trajectoryIterator->valid)
+            if (!g_Ros_Controller.bStopMotion && ctrlGroup->hasDataToProcess && ctrlGroup->trajectoryIterator != NULL && ctrlGroup->trajectoryIterator->valid)
             {
-                if (g_Ros_Controller.bStopMotion)
-                {
-                    bzero(ctrlGroup->trajectoryToProcess, sizeof(ctrlGroup->trajectoryToProcess));
-                    ctrlGroup->hasDataToProcess = FALSE;
-                    continue;
-                }
 
                 Ros_Debug_BroadcastMsg("Processing next point in trajectory [Group #%d - T=%.3f: (%7.4f, %7.4f, %7.4f, %7.4f, %7.4f, %7.4f)]",
                     ctrlGroup->groupNo, (double)ctrlGroup->trajectoryIterator->time * 0.001,
@@ -559,7 +553,7 @@ void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup)
             } // IF this group has a point to process
             else
             {
-                if (Ros_MotionControl_IsMotionMode_Trajectory())
+                if (g_Ros_Controller.bStopMotion || Ros_MotionControl_IsMotionMode_Trajectory())
                 {
                     bzero(ctrlGroup->trajectoryToProcess, sizeof(ctrlGroup->trajectoryToProcess));
                     ctrlGroup->hasDataToProcess = FALSE;
@@ -1045,7 +1039,7 @@ void Ros_MotionControl_IncMoveLoopStart() //<-- IP_CLK priority task
 
                 Ros_ActionServer_FJT_UpdateProgressTracker(&moveData);
             }
-            else
+            else 
                 ret = 0;
 
             if (ret != 0)
@@ -1224,7 +1218,7 @@ BOOL Ros_MotionControl_StopMotion(BOOL bKeepJobRunning)
             bStopped = TRUE;
             break;
         }
-        else
+        else 
             Ros_Sleep(1);
     }
 

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -1219,14 +1219,7 @@ BOOL Ros_MotionControl_StopMotion(BOOL bKeepJobRunning)
     // Check that background processing of message has been stopped
     for (checkCnt = 0; checkCnt < MOTION_STOP_TIMEOUT; checkCnt++)
     {
-        BOOL bAtLeastOne = FALSE;
-        for (int i = 0; i < g_Ros_Controller.numGroup; i += 1)
-        {
-            if (g_Ros_Controller.ctrlGroups[i]->hasDataToProcess)
-                bAtLeastOne = TRUE;
-        }
-
-        if (!bAtLeastOne)
+        if (!Ros_MotionControl_HasDataToProcess())
         {
             bStopped = TRUE;
             break;


### PR DESCRIPTION
I believe that this should fix #76. I also included a fix for #346 because it made solving #76 a little bit less confusing. 

The problem is that made it so `stop_traj_mode` sometimes failed is that  `hasDataToProcess` is never set to `FALSE` during point queue mode, even after `bStopMotion` is set to `true`. That is because `ctrlGroup->trajectoryIterator->valid` is set to `FALSE` after the first point is queued. Because of this, the first condition in the code snippet below fails, and it never reaches the `if(bStopMotion)` block. 

https://github.com/Yaskawa-Global/motoros2/blob/b0eff07cf9a962aa134d96db2b542ae02421d468/src/MotionControl.c#L370-L378 

Slightly related, but `hasDataToProcess` a bit misleading. In point queue mode, there can be no data sitting in the queue/no data to process, but `hasDataToProcess` is true. I do believe that it is an accurate name for trajectory mode, though. 