### PR TITLE
Change time functions

### DIFF
--- a/src/TimeConversionUtils.h
+++ b/src/TimeConversionUtils.h
@@ -34,6 +34,23 @@ static inline void Ros_Nanos_To_Duration_Msg(INT64 x, builtin_interfaces__msg__D
     y->nanosec = (x % 1000000000LL);
 }
 
+static inline INT64 Ros_Time_Msg_To_Millis(builtin_interfaces__msg__Time const* const x)
+{
+    return ((INT64)x->sec * 1000) + (INT64)(x->nanosec * 0.000001);
+}
+
+static inline INT64 Ros_Time_Msg_To_Nanos(builtin_interfaces__msg__Time const* const x)
+{
+    return ((INT64)x->sec * 1000000000LL) + (INT64)x->nanosec;
+}
+
+static inline void Ros_Millis_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time* const y)
+{
+    y->sec = x / 1000;
+    y->nanosec = (x % 1000) * 1000000;
+}
+
+
 static inline void Ros_Nanos_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time* const y)
 {
     y->sec = x / 1000000000LL;

--- a/src/TimeConversionUtils.h
+++ b/src/TimeConversionUtils.h
@@ -14,7 +14,7 @@
 
 static inline INT64 Ros_Duration_Msg_To_Millis(builtin_interfaces__msg__Duration const* const x)
 {
-    return (INT64)(x->sec * 1000) + (INT64)(x->nanosec * 0.000001);
+    return ((INT64)x->sec * 1000) + (INT64)(x->nanosec * 0.000001);
 }
 
 static inline INT64 Ros_Duration_Msg_To_Nanos(builtin_interfaces__msg__Duration const* const x)


### PR DESCRIPTION
`Ros_Duration_Msg_To_Millis` was previously broken because the calculation would have a 32 bit result that would overflow before being cast. We just never ran into that problem because most durations are relatively short and there is no real chance of overflow unless a duration is at least several weeks long (which is obviously unlikely). I only realized that it was broken because I was trying to write `Ros_Time_Msg_To_Millis` by copying the contents of `Ros_Duration_Msg_To_Millis` and it was overflowing there. 

I added more of the time message functions, because it will be useful for issues that may be completed in the future, (#29, #51, possibly others). 