### PR TITLE
Simplify motion control

### DIFF
--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -53,10 +53,6 @@ Init_Trajectory_Status Ros_MotionControl_Init(rosidl_runtime_c__String__Sequence
         bzero(g_Ros_Controller.ctrlGroups[grpIndex]->trajectoryToProcess, sizeof(JointMotionData) * MAX_NUMBER_OF_POINTS_PER_TRAJECTORY);
     }
 
-    //------------------------------------------------------------
-    //The trajectory contains information for all groups. Determine which groups are used by looking at the 'joint names'.
-    BOOL bGroupIsUsed[MAX_CONTROLLABLE_GROUPS];
-    bzero(bGroupIsUsed, sizeof(bGroupIsUsed));
     
     if (g_Ros_Controller.totalAxesCount != sequenceGoalJointNames->size)
     {
@@ -153,13 +149,10 @@ Init_Trajectory_Status Ros_MotionControl_Init(rosidl_runtime_c__String__Sequence
         if (convertStatus != INIT_TRAJ_OK)
             return convertStatus;
 
-        bGroupIsUsed[grpIndex] = TRUE;
     } //for each joint in a single trajectory point
 
     for (grpIndex = 0; grpIndex < g_Ros_Controller.numGroup; grpIndex += 1)
     {
-        if (!bGroupIsUsed[grpIndex])
-            continue;
 
         CtrlGroup* ctrlGroup = g_Ros_Controller.ctrlGroups[grpIndex];
         Ros_Debug_BroadcastMsg("Initializing trajectory for group #%d", ctrlGroup->groupNo);

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -52,14 +52,10 @@ Init_Trajectory_Status Ros_MotionControl_Init(rosidl_runtime_c__String__Sequence
     int grpIndex, jointIndexInTraj, pointIndex;
 
     //Verify we're not already running a trajectory
-    for (grpIndex = 0; grpIndex < g_Ros_Controller.numGroup; grpIndex += 1)
+    if (Ros_MotionControl_HasDataToProcess())
     {
-        if (g_Ros_Controller.ctrlGroups[grpIndex]->hasDataToProcess)
-        {
-            Ros_Debug_BroadcastMsg("Already processing trajectory data - Rejecting new trajectory (Group #%d)",
-                g_Ros_Controller.ctrlGroups[grpIndex]->groupNo);
-            return INIT_TRAJ_ALREADY_IN_MOTION;
-        }
+        Ros_Debug_BroadcastMsg("Already processing trajectory data - Rejecting new trajectory");
+        return INIT_TRAJ_ALREADY_IN_MOTION;
     }
 
     Ros_MotionControl_AllGroupsInitComplete = FALSE;


### PR DESCRIPTION
`MotionControl.c` had several instances of unused code, code that could have been replaced with a function call, and code that was otherwise duplicated. 

The only real functional change of this PR is that duplicate joint names are checked for all points in `queue_traj_point` mode now, not just for the first point. Everything else is a readability/code duplication removal change. 