### PR TITLE
Include missing libmicroros references

### DIFF
--- a/src/MotoROS2_AllControllers.vcxproj
+++ b/src/MotoROS2_AllControllers.vcxproj
@@ -371,9 +371,11 @@
     <None Include="..\libmicroros_dx200_foxy\libmicroros.dnLib_foxy" />
     <None Include="..\libmicroros_dx200_galactic\libmicroros.dnLib_galactic" />
     <None Include="..\libmicroros_dx200_humble\libmicroros.dnLib_humble" />
+    <None Include="..\libmicroros_dx200_jazzy\libmicroros.dnLib_jazzy" />
     <None Include="..\libmicroros_yrc1000u_foxy\libmicroros.yrcmLib_foxy" />
     <None Include="..\libmicroros_yrc1000u_galactic\libmicroros.yrcmLib_galactic" />
     <None Include="..\libmicroros_yrc1000u_humble\libmicroros.yrcmLib_humble" />
+    <None Include="..\libmicroros_yrc1000u_jazzy\libmicroros.yrcmLib_jazzy" />
     <None Include="..\libmicroros_yrc1000_foxy\libmicroros.yrcLib_foxy" />
     <None Include="..\libmicroros_yrc1000_galactic\libmicroros.yrcLib_galactic" />
     <None Include="..\libmicroros_yrc1000_humble\libmicroros.yrcLib_humble" />

--- a/src/MotoROS2_AllControllers.vcxproj.filters
+++ b/src/MotoROS2_AllControllers.vcxproj.filters
@@ -268,8 +268,14 @@
     <None Include="..\libmicroros_yrc1000_jazzy\libmicroros.yrcLib_jazzy">
       <Filter>MotoPlus Libraries\micro-ROS</Filter>
     </None>
-	<None Include="..\doc\network_configuration.md">
+    <None Include="..\doc\network_configuration.md">
       <Filter>Docs\doc</Filter>
+    </None>
+    <None Include="..\libmicroros_dx200_jazzy\libmicroros.dnLib_jazzy">
+      <Filter>MotoPlus Libraries\micro-ROS</Filter>
+    </None>
+    <None Include="..\libmicroros_yrc1000u_jazzy\libmicroros.yrcmLib_jazzy">
+      <Filter>MotoPlus Libraries\micro-ROS</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I was preparing for the 0.2.0 release, and I took a look at the binaries from the batch build for DX200 and YRC1000 and realized that they were far smaller than they should have been and were missing necessary code. I figured out that it was because `libmicroros.dnLib_jazzy` and `libmicroros.yrcmLib_jazzy` were missing. They have been building properly, but wouldn't have run.