### PR TITLE
Fix debug log statement

### DIFF
--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -186,17 +186,17 @@ CtrlGroup* Ros_CtrlGroup_Create(int groupIndex, BOOL bIsLastGrpToInit, float int
         }
         Ros_Debug_BroadcastMsg(startupMessage);
 
-        Ros_Debug_BroadcastMsg("maxInc[%d] (in motoman joint order): %d, %d, %d, %d, %d, %d, %d",
+        Ros_Debug_BroadcastMsg("maxInc[%d] (in motoman joint order): %d, %d, %d, %d, %d, %d, %d, %d",
             groupIndex,
             ctrlGroup->maxInc.maxIncrement[0],ctrlGroup->maxInc.maxIncrement[1],ctrlGroup->maxInc.maxIncrement[2],
             ctrlGroup->maxInc.maxIncrement[3],ctrlGroup->maxInc.maxIncrement[4],ctrlGroup->maxInc.maxIncrement[5],
-            ctrlGroup->maxInc.maxIncrement[6]);
+            ctrlGroup->maxInc.maxIncrement[6],ctrlGroup->maxInc.maxIncrement[7]);
 
-        Ros_Debug_BroadcastMsg("maxSpeed[%d] (in ros joint order): %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f",
+        Ros_Debug_BroadcastMsg("maxSpeed[%d] (in ros joint order): %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f, %.6f",
             groupIndex,
             ctrlGroup->maxSpeed[0],ctrlGroup->maxSpeed[1],ctrlGroup->maxSpeed[2],
             ctrlGroup->maxSpeed[3],ctrlGroup->maxSpeed[4],ctrlGroup->maxSpeed[5],
-            ctrlGroup->maxSpeed[6]);
+            ctrlGroup->maxSpeed[6],ctrlGroup->maxSpeed[7]);
 
         //----------------------------------------------------------------
         if(bInitOk == FALSE)

--- a/src/MotionControl.c
+++ b/src/MotionControl.c
@@ -325,10 +325,11 @@ void Ros_MotionControl_AddToIncQueueProcess(CtrlGroup* ctrlGroup)
             if (!g_Ros_Controller.bStopMotion && ctrlGroup->hasDataToProcess && ctrlGroup->trajectoryIterator != NULL && ctrlGroup->trajectoryIterator->valid)
             {
 
-                Ros_Debug_BroadcastMsg("Processing next point in trajectory [Group #%d - T=%.3f: (%7.4f, %7.4f, %7.4f, %7.4f, %7.4f, %7.4f)]",
+                Ros_Debug_BroadcastMsg("Processing next point in trajectory [Group #%d - T=%.3f: (%7.4f, %7.4f, %7.4f, %7.4f, %7.4f, %7.4f, %7.4f, %7.4f)]",
                     ctrlGroup->groupNo, (double)ctrlGroup->trajectoryIterator->time * 0.001,
                     ctrlGroup->trajectoryIterator->pos[0], ctrlGroup->trajectoryIterator->pos[1], ctrlGroup->trajectoryIterator->pos[2],
-                    ctrlGroup->trajectoryIterator->pos[3], ctrlGroup->trajectoryIterator->pos[4], ctrlGroup->trajectoryIterator->pos[5]);
+                    ctrlGroup->trajectoryIterator->pos[3], ctrlGroup->trajectoryIterator->pos[4], ctrlGroup->trajectoryIterator->pos[5],
+                    ctrlGroup->trajectoryIterator->pos[6], ctrlGroup->trajectoryIterator->pos[7]);
 
                 //-------------------------------------
                 // Check that incoming data is valid


### PR DESCRIPTION
It previously always assumed that there would be 6 axes. Now it makes no assumptions about the number of axes.

This is a lot of code for such a small fix. I would be fine with changing it to not print out the nice formatting (i.e. commas, parentheses, brackets) that require more code/calls to `snprintf`. Or we could just omit the position altogether and print only the timestamp and group number, that should be sufficient to identify the point sent, but it may make debugging harder. Or we could just go with what I have submitted here. I don't have a strong opinion. I'm happy to make changes. 