### PR TITLE
Time utils fix

### DIFF
--- a/src/MotoROS.h
+++ b/src/MotoROS.h
@@ -76,6 +76,8 @@
 #include <motoros2_interfaces/srv/start_point_queue_mode.h>
 #include <motoros2_interfaces/srv/queue_traj_point.h>
 #include <motoros2_interfaces/srv/select_motion_tool.h>
+#include <builtin_interfaces/msg/duration.h>
+#include <builtin_interfaces/msg/time.h>
 
 //============================================
 // MotoROS
@@ -109,6 +111,7 @@
 #include "Tests_RosMotoPlusConversionUtils.h"
 #include "Tests_ControllerStatusIO.h"
 #include "Tests_ActionServer_FJT.h"
+#include "Tests_TimeConversionUtils.h"
 #include "FauxCommandLineArgs.h"
 #include "InformCheckerAndGenerator.h"
 #include "MathConstants.h"

--- a/src/MotoROS2_AllControllers.vcxproj
+++ b/src/MotoROS2_AllControllers.vcxproj
@@ -454,6 +454,7 @@
     <ClCompile Include="FauxCommandLineArgs.c" />
     <ClCompile Include="Ros_mpGetRobotCalibrationData.c" />
     <ClCompile Include="RosMotoPlusConversionUtils.c" />
+    <ClCompile Include="Tests_TimeConversionUtils.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ConfigFile.h" />
@@ -479,6 +480,7 @@
     <ClInclude Include="Tests_CtrlGroup.h" />
     <ClInclude Include="Tests_TestUtils.h" />
     <ClInclude Include="Tests_RosMotoPlusConversionUtils.h" />
+    <ClInclude Include="Tests_TimeConversionUtils.h" />
     <ClInclude Include="TimeConversionUtils.h" />
     <ClInclude Include="MotionControl.h" />
     <ClInclude Include="ActionServer_FJT.h" />

--- a/src/MotoROS2_AllControllers.vcxproj.filters
+++ b/src/MotoROS2_AllControllers.vcxproj.filters
@@ -366,6 +366,9 @@
     <ClCompile Include="Tests_ActionServer_FJT.c">
       <Filter>Source Files\Tests</Filter>
     </ClCompile>
+    <ClCompile Include="Tests_TimeConversionUtils.c">
+      <Filter>Source Files\Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MotoROS.h">
@@ -478,6 +481,9 @@
     </ClInclude>
     <ClInclude Include="Tests_ActionServer_FJT.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Tests_TimeConversionUtils.h">
+      <Filter>Header Files\Tests</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/Tests_TestUtils.c
+++ b/src/Tests_TestUtils.c
@@ -30,4 +30,32 @@ BOOL Ros_Testing_CompareLong(long a, long b)
     return ok;
 }
 
+BOOL Ros_Testing_INT64_Equals(INT64 a, INT64 b)
+{
+    BOOL ok = a == b;
+
+    if (!ok)
+        Ros_Debug_BroadcastMsg("Fail: %lld != %lld", a, b);
+
+    return ok;
+}
+
+BOOL Ros_Testing_Timespec_Equals(const struct timespec* lhs, const struct timespec* rhs)
+{
+    BOOL ok = lhs->tv_sec == rhs->tv_sec;
+
+    if (!ok)
+    {
+        Ros_Debug_BroadcastMsg("Fail timespec seconds: %d != %d", lhs->tv_sec, rhs->tv_sec);
+    }
+
+    ok &= lhs->tv_nsec == rhs->tv_nsec;
+
+    if (!ok)
+    {
+        Ros_Debug_BroadcastMsg("Fail timespec nanos: %d != %d", lhs->tv_nsec, rhs->tv_nsec);
+    }
+    return ok;
+}
+
 #endif //MOTOROS2_TESTING_ENABLE

--- a/src/Tests_TestUtils.h
+++ b/src/Tests_TestUtils.h
@@ -12,7 +12,8 @@
 
 extern BOOL Ros_Testing_CompareDouble(double a, double b);
 extern BOOL Ros_Testing_CompareLong(long a, long b);
-
+extern BOOL Ros_Testing_INT64_Equals(INT64 a, INT64 b);
+extern BOOL Ros_Testing_Timespec_Equals(const struct timespec* lhs, const struct timespec* rhs);
 #endif //MOTOROS2_TESTING_ENABLE
 
 #endif  // MOTOROS2_TESTS_TEST_UTILS_H

--- a/src/Tests_TimeConversionUtils.c
+++ b/src/Tests_TimeConversionUtils.c
@@ -44,11 +44,11 @@ BOOL Ros_Testing_Ros_Duration_Msg_To_Millis()
 
     const builtin_interfaces__msg__Duration M8 = { INT_MIN, 0 };
     millis = Ros_Duration_Msg_To_Millis(&M8);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL, millis);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e3), millis);
 
     const builtin_interfaces__msg__Duration M9 = { INT_MIN, 999999999 };
     millis = Ros_Duration_Msg_To_Millis(&M9);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL + 999, millis);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e3) + 999, millis);
 
     Ros_Debug_BroadcastMsg("Testing Ros_Duration_Msg_To_Millis: %s", bSuccess ? "PASS" : "FAIL");
     return bSuccess;
@@ -89,11 +89,11 @@ BOOL Ros_Testing_Ros_Duration_Msg_To_Nanos()
 
     const builtin_interfaces__msg__Duration M8 = { INT_MIN, 864 };
     nanos = Ros_Duration_Msg_To_Nanos(&M8);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL + 864, nanos);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e9) + 864, nanos);
 
     const builtin_interfaces__msg__Duration M9 = { INT_MIN, 0 };
     nanos = Ros_Duration_Msg_To_Nanos(&M9);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL, nanos);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e9), nanos);
 
     Ros_Debug_BroadcastMsg("Testing Ros_Duration_Msg_To_Nanos: %s", bSuccess ? "PASS" : "FAIL");
     return bSuccess;
@@ -150,7 +150,7 @@ BOOL Ros_Testing_Ros_Millis_To_Duration_Msg()
 
     M1.sec = INT_MIN;
     M1.nanosec = 999000000;
-    millis = INT_MIN * 1000LL + 999;
+    millis = INT_MIN * ((INT64)1e3) + 999;
     Ros_Millis_To_Duration_Msg(millis, &M2);
     bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
 
@@ -203,7 +203,7 @@ BOOL Ros_Testing_Ros_Nanos_To_Duration_Msg()
 
     M1.sec = INT_MIN;
     M1.nanosec = 0;
-    nanos = INT_MIN * 1000LL * 1000LL * 1000LL;
+    nanos = INT_MIN * ((INT64)1e9);
     Ros_Nanos_To_Duration_Msg(nanos, &M2);
     bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
 
@@ -246,11 +246,11 @@ BOOL Ros_Testing_Ros_Time_Msg_To_Millis()
 
     const builtin_interfaces__msg__Time M8 = { INT_MIN, 0 };
     millis = Ros_Time_Msg_To_Millis(&M8);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL, millis);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e3), millis);
 
     const builtin_interfaces__msg__Time M9 = { INT_MIN, 999999999 };
     millis = Ros_Time_Msg_To_Millis(&M9);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL + 999, millis);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e3) + 999, millis);
 
     Ros_Debug_BroadcastMsg("Testing Ros_Time_Msg_To_Millis: %s", bSuccess ? "PASS" : "FAIL");
     return bSuccess;
@@ -291,11 +291,11 @@ BOOL Ros_Testing_Ros_Time_Msg_To_Nanos()
 
     const builtin_interfaces__msg__Time M8 = { INT_MIN, 864 };
     nanos = Ros_Time_Msg_To_Nanos(&M8);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL + 864, nanos);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e9) + 864, nanos);
 
     const builtin_interfaces__msg__Time M9 = { INT_MIN, 0 };
     nanos = Ros_Time_Msg_To_Nanos(&M9);
-    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL, nanos);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * ((INT64)1e9), nanos);
 
     Ros_Debug_BroadcastMsg("Testing Ros_Time_Msg_To_Nanos: %s", bSuccess ? "PASS" : "FAIL");
     return bSuccess;
@@ -352,7 +352,7 @@ BOOL Ros_Testing_Ros_Millis_To_Time_Msg()
 
     M1.sec = INT_MIN;
     M1.nanosec = 999000000;
-    millis = INT_MIN * 1000LL + 999;
+    millis = INT_MIN * ((INT64)1e3) + 999;
     Ros_Millis_To_Time_Msg(millis, &M2);
     bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
 
@@ -405,7 +405,7 @@ BOOL Ros_Testing_Ros_Nanos_To_Time_Msg()
 
     M1.sec = INT_MIN;
     M1.nanosec = 0;
-    nanos = INT_MIN * 1000LL * 1000LL * 1000LL;
+    nanos = INT_MIN * ((INT64)1e9);
     Ros_Nanos_To_Time_Msg(nanos, &M2);
     bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
 
@@ -448,16 +448,16 @@ BOOL Ros_Testing_Ros_Nanos_To_Timespec()
     return bSuccess;
 }
 
-BOOL Ros_Testing_Mixed_Time_Testing() 
+BOOL Ros_Testing_Mixed_Time_Testing()
 {
     BOOL bSuccess = TRUE;
     INT64 output;
     builtin_interfaces__msg__Time time_msg, output_time_msg;
     builtin_interfaces__msg__Duration duration_msg, output_duration_msg;
 
-    
+
     INT64 millisecond_inputs[] = { 0, 1, 99, 1000, 99999, 1743788456057, 2147483647999 };
-    for (int i = 0; i < sizeof(millisecond_inputs) / sizeof(INT64); i++) 
+    for (int i = 0; i < sizeof(millisecond_inputs) / sizeof(INT64); i++)
     {
         Ros_Millis_To_Duration_Msg(millisecond_inputs[i], &duration_msg);
         output = Ros_Duration_Msg_To_Millis(&duration_msg);

--- a/src/Tests_TimeConversionUtils.c
+++ b/src/Tests_TimeConversionUtils.c
@@ -1,0 +1,587 @@
+// Tests_TimeConversionUtils.c
+
+// SPDX-FileCopyrightText: 2025, Yaskawa America, Inc.
+// SPDX-FileCopyrightText: 2025, Delft University of Technology
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifdef MOTOROS2_TESTING_ENABLE
+
+#include "MotoROS.h"
+
+BOOL Ros_Testing_Ros_Duration_Msg_To_Millis()
+{
+    BOOL bSuccess = TRUE;
+    INT64 millis;
+
+    const builtin_interfaces__msg__Duration M1 = { 0, 0 };
+    millis = Ros_Duration_Msg_To_Millis(&M1);
+    bSuccess &= Ros_Testing_INT64_Equals(0, millis);
+
+    const builtin_interfaces__msg__Duration M2 = { 0, 499999999 };
+    millis = Ros_Duration_Msg_To_Millis(&M2);
+    bSuccess &= Ros_Testing_INT64_Equals(499, millis);
+
+    const builtin_interfaces__msg__Duration M3 = {0, 500000000};
+    millis = Ros_Duration_Msg_To_Millis(&M3);
+    bSuccess &= Ros_Testing_INT64_Equals(500, millis);
+
+    const builtin_interfaces__msg__Duration M4 = { 1, 864 };
+    millis = Ros_Duration_Msg_To_Millis(&M4);
+    bSuccess &= Ros_Testing_INT64_Equals(1000, millis);
+
+    const builtin_interfaces__msg__Duration M5 = { 999, 1000000 };
+    millis = Ros_Duration_Msg_To_Millis(&M5);
+    bSuccess &= Ros_Testing_INT64_Equals(999001, millis);
+
+    const builtin_interfaces__msg__Duration M6 = { -1, 0 };
+    millis = Ros_Duration_Msg_To_Millis(&M6);
+    bSuccess &= Ros_Testing_INT64_Equals(-1000, millis);
+
+    const builtin_interfaces__msg__Duration M7 = { -1, 1000000 };
+    millis = Ros_Duration_Msg_To_Millis(&M7);
+    bSuccess &= Ros_Testing_INT64_Equals(-999, millis);
+
+    const builtin_interfaces__msg__Duration M8 = { INT_MIN, 0 };
+    millis = Ros_Duration_Msg_To_Millis(&M8);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL, millis);
+
+    const builtin_interfaces__msg__Duration M9 = { INT_MIN, 999999999 };
+    millis = Ros_Duration_Msg_To_Millis(&M9);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL + 999, millis);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Duration_Msg_To_Millis: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Duration_Msg_To_Nanos()
+{
+    BOOL bSuccess = TRUE;
+    INT64 nanos;
+
+    const builtin_interfaces__msg__Duration M1 = { 0, 0 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M1);
+    bSuccess &= Ros_Testing_INT64_Equals(0, nanos);
+
+    const builtin_interfaces__msg__Duration M2 = { 0, 499999999 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M2);
+    bSuccess &= Ros_Testing_INT64_Equals(499999999, nanos);
+
+    const builtin_interfaces__msg__Duration M3 = { 0, 500000000 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M3);
+    bSuccess &= Ros_Testing_INT64_Equals(500000000, nanos);
+
+    const builtin_interfaces__msg__Duration M4 = { 1, 864 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M4);
+    bSuccess &= Ros_Testing_INT64_Equals(1000000864LL, nanos);
+
+    const builtin_interfaces__msg__Duration M5 = { 999, 1000000 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M5);
+    bSuccess &= Ros_Testing_INT64_Equals(999001000000, nanos);
+
+    const builtin_interfaces__msg__Duration M6 = { -1, 499999999 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M6);
+    bSuccess &= Ros_Testing_INT64_Equals(-500000001, nanos);
+
+    const builtin_interfaces__msg__Duration M7= { -1, 0 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M7);
+    bSuccess &= Ros_Testing_INT64_Equals(-1000000000, nanos);
+
+    const builtin_interfaces__msg__Duration M8 = { INT_MIN, 864 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M8);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL + 864, nanos);
+
+    const builtin_interfaces__msg__Duration M9 = { INT_MIN, 0 };
+    nanos = Ros_Duration_Msg_To_Nanos(&M9);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL, nanos);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Duration_Msg_To_Nanos: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Millis_To_Duration_Msg()
+{
+    BOOL bSuccess = TRUE;
+    INT64 millis;
+
+    builtin_interfaces__msg__Duration M1, M2;
+
+    M1.sec = 0;
+    M1.nanosec = 0;
+    millis = 0;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = 0;
+    M1.nanosec = 999000000;
+    millis = 999;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = 0;
+    M1.nanosec = 999999999;
+    millis = 999;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = 10000000;
+    M1.nanosec = 98353503;
+    millis = 10000000098;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 0;
+    millis = -1000;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 1000000;
+    millis = -999;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 999000000;
+    millis = -1;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = INT_MIN;
+    M1.nanosec = 999000000;
+    millis = INT_MIN * 1000LL + 999;
+    Ros_Millis_To_Duration_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Millis_To_Duration_Msg: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Nanos_To_Duration_Msg()
+{
+    BOOL bSuccess = TRUE;
+    INT64 nanos;
+
+    builtin_interfaces__msg__Duration M1, M2;
+
+    M1.sec = 0;
+    M1.nanosec = 0;
+    nanos = 0;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = 0;
+    M1.nanosec = 99999999LL;
+    nanos = 99999999LL;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = 8;
+    M1.nanosec = 275937194LL;
+    nanos = 8275937194LL;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = 98375198;
+    M1.nanosec = 1;
+    nanos = 98375198000000001;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 999999999;
+    nanos = -1;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 1;
+    nanos = -999999999;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    M1.sec = INT_MIN;
+    M1.nanosec = 0;
+    nanos = INT_MIN * 1000LL * 1000LL * 1000LL;
+    Ros_Nanos_To_Duration_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Duration__are_equal(&M1, &M2);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Nanos_To_Duration_Msg: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Time_Msg_To_Millis()
+{
+    BOOL bSuccess = TRUE;
+    INT64 millis;
+
+    const builtin_interfaces__msg__Time M1 = { 0, 0 };
+    millis = Ros_Time_Msg_To_Millis(&M1);
+    bSuccess &= Ros_Testing_INT64_Equals(0, millis);
+
+    const builtin_interfaces__msg__Time M2 = { 0, 499999999 };
+    millis = Ros_Time_Msg_To_Millis(&M2);
+    bSuccess &= Ros_Testing_INT64_Equals(499, millis);
+
+    const builtin_interfaces__msg__Time M3 = { 0, 500000000 };
+    millis = Ros_Time_Msg_To_Millis(&M3);
+    bSuccess &= Ros_Testing_INT64_Equals(500, millis);
+
+    const builtin_interfaces__msg__Time M4 = { 1, 864 };
+    millis = Ros_Time_Msg_To_Millis(&M4);
+    bSuccess &= Ros_Testing_INT64_Equals(1000, millis);
+
+    const builtin_interfaces__msg__Time M5 = { 999, 1000000 };
+    millis = Ros_Time_Msg_To_Millis(&M5);
+    bSuccess &= Ros_Testing_INT64_Equals(999001, millis);
+
+    const builtin_interfaces__msg__Time M6 = { -1, 0 };
+    millis = Ros_Time_Msg_To_Millis(&M6);
+    bSuccess &= Ros_Testing_INT64_Equals(-1000, millis);
+
+    const builtin_interfaces__msg__Time M7 = { -1, 1000000 };
+    millis = Ros_Time_Msg_To_Millis(&M7);
+    bSuccess &= Ros_Testing_INT64_Equals(-999, millis);
+
+    const builtin_interfaces__msg__Time M8 = { INT_MIN, 0 };
+    millis = Ros_Time_Msg_To_Millis(&M8);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL, millis);
+
+    const builtin_interfaces__msg__Time M9 = { INT_MIN, 999999999 };
+    millis = Ros_Time_Msg_To_Millis(&M9);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL + 999, millis);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Time_Msg_To_Millis: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Time_Msg_To_Nanos()
+{
+    BOOL bSuccess = TRUE;
+    INT64 nanos;
+
+    const builtin_interfaces__msg__Time M1 = { 0, 0 };
+    nanos = Ros_Time_Msg_To_Nanos(&M1);
+    bSuccess &= Ros_Testing_INT64_Equals(0, nanos);
+
+    const builtin_interfaces__msg__Time M2 = { 0, 499999999 };
+    nanos = Ros_Time_Msg_To_Nanos(&M2);
+    bSuccess &= Ros_Testing_INT64_Equals(499999999, nanos);
+
+    const builtin_interfaces__msg__Time M3 = { 0, 500000000 };
+    nanos = Ros_Time_Msg_To_Nanos(&M3);
+    bSuccess &= Ros_Testing_INT64_Equals(500000000, nanos);
+
+    const builtin_interfaces__msg__Time M4 = { 1, 864 };
+    nanos = Ros_Time_Msg_To_Nanos(&M4);
+    bSuccess &= Ros_Testing_INT64_Equals(1000000864LL, nanos);
+
+    const builtin_interfaces__msg__Time M5 = { 999, 1000000 };
+    nanos = Ros_Time_Msg_To_Nanos(&M5);
+    bSuccess &= Ros_Testing_INT64_Equals(999001000000, nanos);
+
+    const builtin_interfaces__msg__Time M6 = { -1, 499999999 };
+    nanos = Ros_Time_Msg_To_Nanos(&M6);
+    bSuccess &= Ros_Testing_INT64_Equals(-500000001, nanos);
+
+    const builtin_interfaces__msg__Time M7 = { -1, 0 };
+    nanos = Ros_Time_Msg_To_Nanos(&M7);
+    bSuccess &= Ros_Testing_INT64_Equals(-1000000000, nanos);
+
+    const builtin_interfaces__msg__Time M8 = { INT_MIN, 864 };
+    nanos = Ros_Time_Msg_To_Nanos(&M8);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL + 864, nanos);
+
+    const builtin_interfaces__msg__Time M9 = { INT_MIN, 0 };
+    nanos = Ros_Time_Msg_To_Nanos(&M9);
+    bSuccess &= Ros_Testing_INT64_Equals(INT_MIN * 1000LL * 1000LL * 1000LL, nanos);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Time_Msg_To_Nanos: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Millis_To_Time_Msg()
+{
+    BOOL bSuccess = TRUE;
+    INT64 millis;
+
+    builtin_interfaces__msg__Time M1, M2;
+
+    M1.sec = 0;
+    M1.nanosec = 0;
+    millis = 0;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = 0;
+    M1.nanosec = 1000000;
+    millis = 1;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = 0;
+    M1.nanosec = 999000000;
+    millis = 999;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = 10000000;
+    M1.nanosec = 98000000;
+    millis = 10000000098;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 0;
+    millis = -1000;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 1000000;
+    millis = -999;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 999000000;
+    millis = -1;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = INT_MIN;
+    M1.nanosec = 999000000;
+    millis = INT_MIN * 1000LL + 999;
+    Ros_Millis_To_Time_Msg(millis, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Millis_To_Time_Msg: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Nanos_To_Time_Msg()
+{
+    BOOL bSuccess = TRUE;
+    INT64 nanos;
+
+    builtin_interfaces__msg__Time M1, M2;
+
+    M1.sec = 0;
+    M1.nanosec = 0;
+    nanos = 0;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = 0;
+    M1.nanosec = 99999999LL;
+    nanos = 99999999LL;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = 8;
+    M1.nanosec = 275937194LL;
+    nanos = 8275937194LL;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = 98375198;
+    M1.nanosec = 1;
+    nanos = 98375198000000001;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 999999999;
+    nanos = -1;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = -1;
+    M1.nanosec = 1;
+    nanos = -999999999;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    M1.sec = INT_MIN;
+    M1.nanosec = 0;
+    nanos = INT_MIN * 1000LL * 1000LL * 1000LL;
+    Ros_Nanos_To_Time_Msg(nanos, &M2);
+    bSuccess &= builtin_interfaces__msg__Time__are_equal(&M1, &M2);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Nanos_To_Time_Msg: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Ros_Nanos_To_Timespec()
+{
+    BOOL bSuccess = TRUE;
+    INT64 nanos;
+
+    struct timespec M1, M2;
+
+    M1.tv_sec = 0;
+    M1.tv_nsec = 0;
+    nanos = 0;
+    Ros_Nanos_To_Timespec(nanos, &M2);
+    bSuccess &= Ros_Testing_Timespec_Equals(&M1, &M2);
+
+    M1.tv_sec = 0;
+    M1.tv_nsec = 99999999LL;
+    nanos = 99999999LL;
+    Ros_Nanos_To_Timespec(nanos, &M2);
+    bSuccess &= Ros_Testing_Timespec_Equals(&M1, &M2);
+
+    M1.tv_sec = 8;
+    M1.tv_nsec = 275937194LL;
+    nanos = 8275937194LL;
+    Ros_Nanos_To_Timespec(nanos, &M2);
+    bSuccess &= Ros_Testing_Timespec_Equals(&M1, &M2);
+
+    M1.tv_sec = 98375198;
+    M1.tv_nsec = 1;
+    nanos = 98375198000000001;
+    Ros_Nanos_To_Timespec(nanos, &M2);
+    bSuccess &= Ros_Testing_Timespec_Equals(&M1, &M2);
+
+    Ros_Debug_BroadcastMsg("Testing Ros_Testing_Timespec_Equals: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_Mixed_Time_Testing() 
+{
+    BOOL bSuccess = TRUE;
+    INT64 output;
+    builtin_interfaces__msg__Time time_msg, output_time_msg;
+    builtin_interfaces__msg__Duration duration_msg, output_duration_msg;
+
+    
+    INT64 millisecond_inputs[] = { 0, 1, 99, 1000, 99999, 1743788456057, 2147483647999 };
+    for (int i = 0; i < sizeof(millisecond_inputs) / sizeof(INT64); i++) 
+    {
+        Ros_Millis_To_Duration_Msg(millisecond_inputs[i], &duration_msg);
+        output = Ros_Duration_Msg_To_Millis(&duration_msg);
+        bSuccess &= Ros_Testing_INT64_Equals(millisecond_inputs[i], output);
+
+        Ros_Millis_To_Time_Msg(millisecond_inputs[i], &time_msg);
+        output = Ros_Time_Msg_To_Millis(&time_msg);
+        bSuccess &= Ros_Testing_INT64_Equals(millisecond_inputs[i], output);
+    }
+
+    INT64 nanosecond_inputs[] = { 0, 1, 999999, 1000000, 1743788456057000000, 2147483647999000000 };
+    for (int i = 0; i < sizeof(nanosecond_inputs) / sizeof(INT64); i++)
+    {
+        Ros_Nanos_To_Duration_Msg(nanosecond_inputs[i], &duration_msg);
+        output = Ros_Duration_Msg_To_Nanos(&duration_msg);
+        bSuccess &= Ros_Testing_INT64_Equals(nanosecond_inputs[i], output);
+
+        Ros_Nanos_To_Time_Msg(nanosecond_inputs[i], &time_msg);
+        output = Ros_Time_Msg_To_Nanos(&time_msg);
+        bSuccess &= Ros_Testing_INT64_Equals(nanosecond_inputs[i], output);
+    }
+
+    const builtin_interfaces__msg__Duration duration_msg_array_nanos[] =
+    {
+        { INT_MIN, 0 },
+        { INT_MIN, 20 },
+        { -1, 0 },
+        { -1, 1 },
+        { -1, 999999999 },
+        { 0, 0 },
+        { 0, 1 },
+        { 0, 999999 },
+        { 0, 1000000 },
+        { 0 , 999999999},
+        { 1 , 0},
+        { 1 , 999999999},
+        { INT_MAX , 999999999},
+    };
+
+    const builtin_interfaces__msg__Time time_msg_array_nanos[] =
+    {
+        { INT_MIN, 0 },
+        { INT_MIN, 20 },
+        { -1, 0 },
+        { -1, 1 },
+        { -1, 999999999 },
+        { 0, 0 },
+        { 0, 1 },
+        { 0, 999999 },
+        { 0, 1000000 },
+        { 0 , 999999999},
+        { 1 , 0},
+        { 1 , 999999999},
+        { INT_MAX , 999999999},
+    };
+
+    for (int i = 0; i < sizeof(duration_msg_array_nanos) / sizeof(builtin_interfaces__msg__Duration); i++)
+    {
+        output = Ros_Duration_Msg_To_Nanos(&duration_msg_array_nanos[i]);
+        Ros_Nanos_To_Duration_Msg(output, &output_duration_msg);
+        bSuccess &= builtin_interfaces__msg__Duration__are_equal(&output_duration_msg , &duration_msg_array_nanos[i]);
+
+        output = Ros_Time_Msg_To_Nanos(&time_msg_array_nanos[i]);
+        Ros_Nanos_To_Time_Msg(output, &output_time_msg);
+        bSuccess &= builtin_interfaces__msg__Time__are_equal(&output_time_msg, &time_msg_array_nanos[i]);
+    }
+
+    const builtin_interfaces__msg__Duration duration_msg_array_millis[] =
+    {
+        { INT_MIN, 0 },
+        { INT_MIN, 2000000 },
+        { -1, 0 },
+        { -1, 1000000 },
+        { -1, 999000000 },
+        { 0, 0 },
+        { 0, 1000000 },
+        { 0, 999000000 },
+        { 1, 0 },
+        { INT_MAX , 999000000},
+    };
+
+    const builtin_interfaces__msg__Time time_msg_array_millis[] =
+    {
+        { INT_MIN, 0 },
+        { INT_MIN, 2000000 },
+        { -1, 0 },
+        { -1, 1000000 },
+        { -1, 999000000 },
+        { 0, 0 },
+        { 0, 1000000 },
+        { 0, 999000000 },
+        { 1, 0 },
+        { INT_MAX , 999000000},
+    };
+
+    for (int i = 0; i < sizeof(duration_msg_array_millis) / sizeof(builtin_interfaces__msg__Duration); i++)
+    {
+        output = Ros_Duration_Msg_To_Millis(&duration_msg_array_millis[i]);
+        Ros_Millis_To_Duration_Msg(output, &output_duration_msg);
+        bSuccess &= builtin_interfaces__msg__Duration__are_equal(&output_duration_msg , &duration_msg_array_millis[i]);
+
+        output = Ros_Time_Msg_To_Millis(&time_msg_array_millis[i]);
+        Ros_Millis_To_Time_Msg(output, &output_time_msg);
+        bSuccess &= builtin_interfaces__msg__Time__are_equal(&output_time_msg, &time_msg_array_millis[i]);
+    }
+    Ros_Debug_BroadcastMsg("Testing mixed time functions: %s", bSuccess ? "PASS" : "FAIL");
+    return bSuccess;
+}
+
+BOOL Ros_Testing_TimeConversionUtils()
+{
+    BOOL bSuccess = TRUE;
+
+    bSuccess &= Ros_Testing_Ros_Duration_Msg_To_Millis();
+    bSuccess &= Ros_Testing_Ros_Duration_Msg_To_Nanos();
+    bSuccess &= Ros_Testing_Ros_Duration_Msg_To_Millis();
+    bSuccess &= Ros_Testing_Ros_Nanos_To_Duration_Msg();
+    bSuccess &= Ros_Testing_Ros_Time_Msg_To_Millis();
+    bSuccess &= Ros_Testing_Ros_Time_Msg_To_Nanos();
+    bSuccess &= Ros_Testing_Ros_Millis_To_Time_Msg();
+    bSuccess &= Ros_Testing_Ros_Nanos_To_Time_Msg();
+    bSuccess &= Ros_Testing_Ros_Nanos_To_Timespec();
+    bSuccess &= Ros_Testing_Mixed_Time_Testing();
+    return bSuccess;
+}
+
+#endif //MOTOROS2_TESTING_ENABLE

--- a/src/Tests_TimeConversionUtils.h
+++ b/src/Tests_TimeConversionUtils.h
@@ -1,0 +1,17 @@
+// Tests_TimeConversionUtils.h
+
+// SPDX-FileCopyrightText: 2025, Yaskawa America, Inc.
+// SPDX-FileCopyrightText: 2025, Delft University of Technology
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MOTOROS2_TESTS_TIME_CONVERSION_UTILS_H
+#define MOTOROS2_TESTS_TIME_CONVERSION_UTILS_H
+
+#ifdef MOTOROS2_TESTING_ENABLE
+
+extern BOOL Ros_Testing_TimeConversionUtils();
+
+#endif //MOTOROS2_TESTING_ENABLE
+
+#endif  // MOTOROS2_TESTS_TIME_CONVERSION_UTILS_H

--- a/src/TimeConversionUtils.h
+++ b/src/TimeConversionUtils.h
@@ -11,56 +11,77 @@
 
 #include "MotoROS.h"
 
+static inline void floor_divide(INT64 dividend, INT64 divisor, INT64* quotient, INT64* remainder)
+{
+    *quotient = dividend / divisor;
+    // If the division has a remainder, and the result is negative,
+    // we need to adjust to floor the result
+    if (dividend % divisor != 0 && ((dividend < 0) != (divisor < 0)))
+    {
+        *quotient -= 1;
+    }
+
+    *remainder = abs(dividend - *quotient * divisor);
+}
 
 static inline INT64 Ros_Duration_Msg_To_Millis(builtin_interfaces__msg__Duration const* const x)
 {
-    return ((INT64)x->sec * 1000) + (INT64)(x->nanosec * 0.000001);
+    return (x->sec * 1000LL) + (x->nanosec / (1000LL * 1000LL));
 }
 
 static inline INT64 Ros_Duration_Msg_To_Nanos(builtin_interfaces__msg__Duration const* const x)
 {
-    return ((INT64)x->sec * 1000000000LL) + (INT64)x->nanosec;
+    return (x->sec * 1000LL * 1000LL * 1000LL) + (x->nanosec);
 }
 
 static inline void Ros_Millis_To_Duration_Msg(INT64 x, builtin_interfaces__msg__Duration* const y)
 {
-    y->sec = x / 1000;
-    y->nanosec = (x % 1000) * 1000000;
+    INT64 remainder, quotient;
+    floor_divide(x, 1000LL, &quotient, &remainder);
+    y->sec = quotient;
+    y->nanosec = remainder * 1000LL * 1000LL;
 }
 
 static inline void Ros_Nanos_To_Duration_Msg(INT64 x, builtin_interfaces__msg__Duration* const y)
 {
-    y->sec = x / 1000000000LL;
-    y->nanosec = (x % 1000000000LL);
+    INT64 remainder, quotient;
+    floor_divide(x, 1000LL * 1000LL * 1000LL, &quotient, &remainder);
+    y->sec = quotient;
+    y->nanosec = remainder;
 }
 
 static inline INT64 Ros_Time_Msg_To_Millis(builtin_interfaces__msg__Time const* const x)
 {
-    return ((INT64)x->sec * 1000) + (INT64)(x->nanosec * 0.000001);
+    return (x->sec * 1000LL) + (x->nanosec / (1000LL * 1000LL));
 }
 
 static inline INT64 Ros_Time_Msg_To_Nanos(builtin_interfaces__msg__Time const* const x)
 {
-    return ((INT64)x->sec * 1000000000LL) + (INT64)x->nanosec;
+    return (x->sec * 1000LL * 1000LL * 1000LL) + x->nanosec;
 }
 
 static inline void Ros_Millis_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time* const y)
 {
-    y->sec = x / 1000;
-    y->nanosec = (x % 1000) * 1000000;
+    INT64 remainder, quotient;
+    floor_divide(x, 1000LL, &quotient, &remainder);
+    y->sec = quotient;
+    y->nanosec = remainder * 1000LL * 1000LL;
 }
-
 
 static inline void Ros_Nanos_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time* const y)
 {
-    y->sec = x / 1000000000LL;
-    y->nanosec = (x % 1000000000LL);
+    INT64 remainder, quotient;
+    floor_divide(x, 1000LL * 1000LL * 1000LL, &quotient, &remainder);
+    y->sec = quotient;
+    y->nanosec = remainder;
 }
 
 static inline void Ros_Nanos_To_Timespec(INT64 x, struct timespec* const y)
 {
-    y->tv_sec = x / 1000000000LL;
-    y->tv_nsec = (x % 1000000000LL);
+    INT64 remainder, quotient;
+    floor_divide(x, 1000LL * 1000LL * 1000LL, &quotient, &remainder);
+    y->tv_sec = quotient;
+    y->tv_nsec = remainder;
 }
 
 

--- a/src/TimeConversionUtils.h
+++ b/src/TimeConversionUtils.h
@@ -26,52 +26,52 @@ static inline void floor_divide(INT64 dividend, INT64 divisor, INT64* quotient, 
 
 static inline INT64 Ros_Duration_Msg_To_Millis(builtin_interfaces__msg__Duration const* const x)
 {
-    return (x->sec * 1000LL) + (x->nanosec / (1000LL * 1000LL));
+    return (x->sec * (INT64)1e3) + (x->nanosec / (INT64)1e6);
 }
 
 static inline INT64 Ros_Duration_Msg_To_Nanos(builtin_interfaces__msg__Duration const* const x)
 {
-    return (x->sec * 1000LL * 1000LL * 1000LL) + (x->nanosec);
+    return (x->sec * (INT64)1e9) + (x->nanosec);
 }
 
 static inline void Ros_Millis_To_Duration_Msg(INT64 x, builtin_interfaces__msg__Duration* const y)
 {
     INT64 remainder, quotient;
-    floor_divide(x, 1000LL, &quotient, &remainder);
+    floor_divide(x, (INT64)1e3, &quotient, &remainder);
     y->sec = quotient;
-    y->nanosec = remainder * 1000LL * 1000LL;
+    y->nanosec = remainder * (INT64)1e6;
 }
 
 static inline void Ros_Nanos_To_Duration_Msg(INT64 x, builtin_interfaces__msg__Duration* const y)
 {
     INT64 remainder, quotient;
-    floor_divide(x, 1000LL * 1000LL * 1000LL, &quotient, &remainder);
+    floor_divide(x, (INT64)1e9, &quotient, &remainder);
     y->sec = quotient;
     y->nanosec = remainder;
 }
 
 static inline INT64 Ros_Time_Msg_To_Millis(builtin_interfaces__msg__Time const* const x)
 {
-    return (x->sec * 1000LL) + (x->nanosec / (1000LL * 1000LL));
+    return (x->sec * (INT64)1e3) + (x->nanosec / ((INT64)1e6));
 }
 
 static inline INT64 Ros_Time_Msg_To_Nanos(builtin_interfaces__msg__Time const* const x)
 {
-    return (x->sec * 1000LL * 1000LL * 1000LL) + x->nanosec;
+    return (x->sec * (INT64)1e9) + x->nanosec;
 }
 
 static inline void Ros_Millis_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time* const y)
 {
     INT64 remainder, quotient;
-    floor_divide(x, 1000LL, &quotient, &remainder);
+    floor_divide(x, (INT64)1e3, &quotient, &remainder);
     y->sec = quotient;
-    y->nanosec = remainder * 1000LL * 1000LL;
+    y->nanosec = remainder * (INT64)1e6;
 }
 
 static inline void Ros_Nanos_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time* const y)
 {
     INT64 remainder, quotient;
-    floor_divide(x, 1000LL * 1000LL * 1000LL, &quotient, &remainder);
+    floor_divide(x, (INT64)1e9, &quotient, &remainder);
     y->sec = quotient;
     y->nanosec = remainder;
 }
@@ -79,7 +79,7 @@ static inline void Ros_Nanos_To_Time_Msg(INT64 x, builtin_interfaces__msg__Time*
 static inline void Ros_Nanos_To_Timespec(INT64 x, struct timespec* const y)
 {
     INT64 remainder, quotient;
-    floor_divide(x, 1000LL * 1000LL * 1000LL, &quotient, &remainder);
+    floor_divide(x, (INT64)1e9, &quotient, &remainder);
     y->tv_sec = quotient;
     y->tv_nsec = remainder;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,7 @@ void RosInitTask()
     bTestResult &= Ros_Testing_RosMotoPlusConversionUtils();
     bTestResult &= Ros_Testing_ControllerStatusIO();
     bTestResult &= Ros_Testing_ActionServer_FJT();
+    bTestResult &= Ros_Testing_TimeConversionUtils();
     bTestResult ? Ros_Debug_BroadcastMsg("Testing SUCCESSFUL") : Ros_Debug_BroadcastMsg("!!! Testing FAILED !!!");
     Ros_Debug_BroadcastMsg("===");
 #endif


### PR DESCRIPTION
Resolves #402

This PR gets rid of the floating point math error that results in inappropriate truncation of ms timestamps. 

It also changes the time utils to work for negative times and negative durations. 

I added a bunch of unit tests. Note that due the problem discussed in #407, the controller will crash if you set the testing flag. So make sure to comment out [these lines](https://github.com/Yaskawa-Global/motoros2/blob/ec13454105c21c9397449f9aa1491a224147cc14/src/main.c#L75-L78) before setting that flag and building. 

This PR is a lot more broad than I was originally planning on it being, mostly because dealing with negative times/durations is more inconvenient than I originally thought. I'm happy to make changes though. 