### PR TITLE
Fix unit tests

### DIFF
--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -55,7 +55,9 @@ const char* Ros_CtrlGroup_GRP_ID_String[] =
 
 CtrlGroup* Ros_CtrlGroup_Ctor()
 {
-    return (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    bzero(grp, sizeof(CtrlGroup));
+    return grp;
 }
 
 void Ros_CtrlGroup_Dtor(CtrlGroup* grp)

--- a/src/CtrlGroup.c
+++ b/src/CtrlGroup.c
@@ -53,6 +53,16 @@ const char* Ros_CtrlGroup_GRP_ID_String[] =
     "s24",
 };
 
+CtrlGroup* Ros_CtrlGroup_Ctor()
+{
+    return (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+}
+
+void Ros_CtrlGroup_Dtor(CtrlGroup* grp)
+{
+    mpFree(grp);
+}
+
 //-------------------------------------------------------------------
 // Create a CtrlGroup data structure for existing group otherwise
 // return NULL

--- a/src/CtrlGroup.h
+++ b/src/CtrlGroup.h
@@ -103,6 +103,9 @@ typedef struct
 // External Functions Declaration
 //---------------------------------
 
+extern CtrlGroup* Ros_CtrlGroup_Ctor();
+extern void Ros_CtrlGroup_Dtor(CtrlGroup* ctrlGroup);
+
 //Initialize specific control group. This should be called for each group connected to the robot
 //controller in numerical order.
 //  int groupNo: Zero based index of the group number (0-3)

--- a/src/Tests_ActionServer_FJT.c
+++ b/src/Tests_ActionServer_FJT.c
@@ -56,6 +56,9 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_empty_jtole
     const size_t NUM_JOINTS = 6;
     double posTolerances[NUM_JOINTS];
 
+    rosidl_runtime_c__String__Sequence__init(&joint_names, NUM_JOINTS);
+    joint_names.size = 0;
+
     //init capacity to NUM_JOINTS, but don't add any elements
     control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
     joint_tolerances.size = 0;
@@ -92,7 +95,6 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_t
     BOOL bSuccess = TRUE;
 
     STATUS status = 0;
-    control_msgs__msg__JointTolerance joint_tolerance;
     control_msgs__msg__JointTolerance__Sequence joint_tolerances;
     rosidl_runtime_c__String__Sequence joint_names;
     const size_t NUM_JOINTS = 6;
@@ -111,9 +113,6 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_out_array_t
     joint_tolerances.size = 0;
 
     //add (at least) a single JointTolerance (don't need to init it, just add it)
-    bzero(&joint_tolerance, sizeof(joint_tolerance));
-    control_msgs__msg__JointTolerance__init(&joint_tolerance);
-    joint_tolerances.data[0] = joint_tolerance;
     joint_tolerances.size = 1;
 
     //call
@@ -139,7 +138,6 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_t
     BOOL bSuccess = TRUE;
 
     STATUS status = 0;
-    control_msgs__msg__JointTolerance joint_tolerance;
     control_msgs__msg__JointTolerance__Sequence joint_tolerances;
     rosidl_runtime_c__String__Sequence joint_names;
     const size_t NUM_JOINTS = 6;
@@ -153,11 +151,8 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_more_jtol_t
     joint_tolerances.size = 0;
 
     //add a single JointTolerance
-    bzero(&joint_tolerance, sizeof(joint_tolerance));
-    control_msgs__msg__JointTolerance__init(&joint_tolerance);
-    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint5");
-    joint_tolerance.position = 1.0;
-    joint_tolerances.data[0] = joint_tolerance;
+    rosidl_runtime_c__String__assign(&joint_tolerances.data[0].name, "joint5");
+    joint_tolerances.data[0].position = 1.0;
     joint_tolerances.size = 1;
 
     //no jnames, zero len output array, but 1 jtol: that's legal, just means the jtol
@@ -193,7 +188,6 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slo
     BOOL bSuccess = TRUE;
 
     STATUS status = 0;
-    control_msgs__msg__JointTolerance joint_tolerance;
     control_msgs__msg__JointTolerance__Sequence joint_tolerances;
     rosidl_runtime_c__String__Sequence joint_names;
     const size_t NUM_JOINTS = 6;
@@ -210,13 +204,10 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slo
     control_msgs__msg__JointTolerance__Sequence__init(&joint_tolerances, NUM_JOINTS);
     joint_tolerances.size = 0;
 
-    bzero(&joint_tolerance, sizeof(joint_tolerance));
-    control_msgs__msg__JointTolerance__init(&joint_tolerance);
-    rosidl_runtime_c__String__assign(&joint_tolerance.name, JOINT_NAME);
-    joint_tolerance.position = J0_POS_TOL;
-    joint_tolerance.velocity = 0.0;
-    joint_tolerance.acceleration = 0.0;
-    joint_tolerances.data[0] = joint_tolerance;
+    rosidl_runtime_c__String__assign(&joint_tolerances.data[0].name, JOINT_NAME);
+    joint_tolerances.data[0].position = J0_POS_TOL;
+    joint_tolerances.data[0].velocity = 0.0;
+    joint_tolerances.data[0].acceleration = 0.0;
     joint_tolerances.size = 1;
 
     status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
@@ -247,7 +238,6 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slo
     BOOL bSuccess = TRUE;
 
     STATUS status = 0;
-    control_msgs__msg__JointTolerance joint_tolerance;
     control_msgs__msg__JointTolerance__Sequence joint_tolerances;
     rosidl_runtime_c__String__Sequence joint_names;
     const size_t NUM_JOINTS = 6;
@@ -267,13 +257,10 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_jtol_in_slo
     joint_tolerances.size = 0;
 
     //add a single JointTolerance
-    bzero(&joint_tolerance, sizeof(joint_tolerance));
-    control_msgs__msg__JointTolerance__init(&joint_tolerance);
-    rosidl_runtime_c__String__assign(&joint_tolerance.name, JOINT_NAME);
-    joint_tolerance.position = J0_POS_TOL;
-    joint_tolerance.velocity = 0.0;
-    joint_tolerance.acceleration = 0.0;
-    joint_tolerances.data[0] = joint_tolerance;
+    rosidl_runtime_c__String__assign(&joint_tolerances.data[0].name, JOINT_NAME);
+    joint_tolerances.data[0].position = J0_POS_TOL;
+    joint_tolerances.data[0].velocity = 0.0;
+    joint_tolerances.data[0].acceleration = 0.0;
     joint_tolerances.size = 1;
 
     status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
@@ -301,7 +288,6 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_settin
     BOOL bSuccess = TRUE;
 
     STATUS status = 0;
-    control_msgs__msg__JointTolerance joint_tolerance;
     control_msgs__msg__JointTolerance__Sequence joint_tolerances;
     rosidl_runtime_c__String__Sequence joint_names;
     const size_t NUM_JOINTS = 3;
@@ -318,23 +304,18 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Parse_GoalPosTolerances_last_settin
     joint_tolerances.size = 0;
 
     //JointTolerance for joint1
-    bzero(&joint_tolerance, sizeof(joint_tolerance));
-    control_msgs__msg__JointTolerance__init(&joint_tolerance);
-    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint1");
-    joint_tolerance.position = 0.123;
-    control_msgs__msg__JointTolerance__copy(&joint_tolerance, &joint_tolerances.data[0]);
+    rosidl_runtime_c__String__assign(&joint_tolerances.data[0].name, "joint1");
+    joint_tolerances.data[0].position = 0.123;
     joint_tolerances.size = 1;
 
     //JointTolerance for joint2
-    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint2");
-    joint_tolerance.position = 0.234;
-    control_msgs__msg__JointTolerance__copy(&joint_tolerance, &joint_tolerances.data[1]);
+    rosidl_runtime_c__String__assign(&joint_tolerances.data[1].name, "joint2");
+    joint_tolerances.data[1].position = 0.234;
     joint_tolerances.size = 2;
 
     //JointTolerance for joint1 -- NOTE: DUPLICATE
-    rosidl_runtime_c__String__assign(&joint_tolerance.name, "joint1");
-    joint_tolerance.position = 0.345;
-    control_msgs__msg__JointTolerance__copy(&joint_tolerance, &joint_tolerances.data[2]);
+    rosidl_runtime_c__String__assign(&joint_tolerances.data[2].name, "joint1");
+    joint_tolerances.data[2].position = 0.345;
     joint_tolerances.size = 3;
 
     status = Ros_ActionServer_FJT_Parse_GoalPosTolerances(&joint_tolerances, &joint_names, posTolerances, NUM_JOINTS);
@@ -474,6 +455,7 @@ static BOOL Ros_Testing_Ros_ActionServer_FJT_Reorder_TrajPt_To_Internal_Order_tr
     //on purpose of course
     bzero(&traj_point, sizeof(traj_point));
     trajectory_msgs__msg__JointTrajectoryPoint__init(&traj_point);
+    rosidl_runtime_c__double__Sequence__init(&traj_point.positions, NUM_JOINTS);
     traj_point.positions.data[0] = 0.0;
     traj_point.positions.size = 1;
 

--- a/src/Tests_ControllerStatusIO.c
+++ b/src/Tests_ControllerStatusIO.c
@@ -9,8 +9,6 @@
 
 #include "MotoROS.h"
 
-#if 0
-
 void Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(CtrlGroup* group, int groupNo, MP_GRP_ID_TYPE groupId)
 {
     bzero(group, sizeof(CtrlGroup));
@@ -344,14 +342,10 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2()
     return bSuccess;
 }
 
-#endif
 
 BOOL Ros_Testing_ControllerStatusIO()
 {
     BOOL bSuccess = TRUE;
-
-    // disabled for now, cause controllers to crash (stack overflow issue perhaps?)
-#if 0
 
     bSuccess &= Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1();
     bSuccess &= Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1();
@@ -362,7 +356,6 @@ BOOL Ros_Testing_ControllerStatusIO()
     bSuccess &= Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1();
     bSuccess &= Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2();
 
-#endif
 
     return bSuccess;
 }

--- a/src/Tests_ControllerStatusIO.c
+++ b/src/Tests_ControllerStatusIO.c
@@ -85,13 +85,12 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0;
 
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
     controller.numGroup = 1;
-    controller.numRobot = 1;
-    controller.ctrlGroups[0] = &grp0;
+    controller.ctrlGroups[0] = grp0;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
 
     //R1: NO warning, nothing to calibrate with a single group
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -102,6 +101,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+
     return bSuccess;
 }
 
@@ -110,16 +111,16 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 2;
-    controller.numRobot = 1;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_B1_GID);
-    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ &grp0, /*base=*/ &grp1);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_B1_GID);
+    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ grp0, /*base=*/ grp1);
 
     //R1+B1: NO warning, as base tracks don't get calibrated
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -130,6 +131,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+
     return bSuccess;
 }
 
@@ -138,15 +142,15 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1R2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 2;
-    controller.numRobot = 1;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_R2_GID);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_R2_GID);
 
     //R1+R2: YES warning, but only if TF enabled AND calib failed to load
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -157,6 +161,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1R2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1R2: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+
     return bSuccess;
 }
 
@@ -165,19 +172,20 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1, grp2;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 3;
-    controller.numRobot = 2;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
-    controller.ctrlGroups[2] = &grp2;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
+    controller.ctrlGroups[2] = grp2;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(&grp2, /*groupNo=*/ 2, /*groupId=*/ MP_B1_GID);
-    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ &grp0, /*base=*/ &grp2);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(grp2, /*groupNo=*/ 2, /*groupId=*/ MP_B1_GID);
+    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ grp0, /*base=*/ grp2);
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_R2_GID);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_R2_GID);
 
     //R1B1+R2: YES warning, but only if TF enabled AND calib failed to load
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -188,6 +196,10 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+    mpFree(grp2);
+
     return bSuccess;
 }
 
@@ -196,15 +208,15 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 2;
-    controller.numRobot = 1;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_S1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_S1_GID);
 
     //R1S1: YES warning, but only if TF enabled AND calib failed to load
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -215,6 +227,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+
     return bSuccess;
 }
 
@@ -223,17 +238,18 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1S2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1, grp2;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 3;
-    controller.numRobot = 1;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
-    controller.ctrlGroups[2] = &grp2;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
+    controller.ctrlGroups[2] = grp2;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_S1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(&grp2, /*groupNo=*/ 2, /*groupId=*/ MP_S2_GID);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_S1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(grp2, /*groupNo=*/ 2, /*groupId=*/ MP_S2_GID);
 
     //R1S1S2: YES warning, but only if TF enabled AND calib failed to load
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -244,6 +260,10 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1S2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1S2: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+    mpFree(grp2);
+
     return bSuccess;
 }
 
@@ -252,19 +272,20 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1, grp2;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 3;
-    controller.numRobot = 1;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
-    controller.ctrlGroups[2] = &grp2;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
+    controller.ctrlGroups[2] = grp2;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_B1_GID);
-    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ &grp0, /*base=*/ &grp1);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_B1_GID);
+    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ grp0, /*base=*/ grp1);
 
-    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(&grp2, /*groupNo=*/ 2, /*groupId=*/ MP_S1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeStationGroup(grp2, /*groupNo=*/ 2, /*groupId=*/ MP_S1_GID);
 
     //R1B1S1: YES warning, but only if TF enabled AND calib failed to load
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -275,6 +296,10 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+    mpFree(grp2);
+
     return bSuccess;
 }
 
@@ -283,22 +308,24 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup grp0, grp1, grp2, grp3;
+    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp3 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
 
     controller.numGroup = 4;
-    controller.numRobot = 2;
-    controller.ctrlGroups[0] = &grp0;
-    controller.ctrlGroups[1] = &grp1;
-    controller.ctrlGroups[2] = &grp2;
-    controller.ctrlGroups[3] = &grp3;
+    controller.ctrlGroups[0] = grp0;
+    controller.ctrlGroups[1] = grp1;
+    controller.ctrlGroups[2] = grp2;
+    controller.ctrlGroups[3] = grp3;
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(&grp1, /*groupNo=*/ 1, /*groupId=*/ MP_B1_GID);
-    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ &grp0, /*base=*/ &grp1);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp0, /*groupNo=*/ 0, /*groupId=*/ MP_R1_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(grp1, /*groupNo=*/ 1, /*groupId=*/ MP_B1_GID);
+    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ grp0, /*base=*/ grp1);
 
-    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(&grp2, /*groupNo=*/ 2, /*groupId=*/ MP_R2_GID);
-    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(&grp3, /*groupNo=*/ 3, /*groupId=*/ MP_B2_GID);
-    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ &grp2, /*base=*/ &grp3);
+    Ros_Testing_ControllerStatusIO_MakeFake6dofRobot(grp2, /*groupNo=*/ 2, /*groupId=*/ MP_R2_GID);
+    Ros_Testing_ControllerStatusIO_MakeFakeBaseGroup(grp3, /*groupNo=*/ 3, /*groupId=*/ MP_B2_GID);
+    Ros_Testing_ControllerStatusIO_AssignRobotToBaseGroup(/*robot=*/ grp2, /*base=*/ grp3);
 
     //R1B1R2B2: YES warning, but only if TF enabled AND calib failed to load
     bSuccess &= FALSE == Ros_Controller_ShouldWarnNoCalibDataLoaded(&controller, /*bCalibLoadedOk=*/ FALSE, /*bPublishTfEnabled=*/ FALSE);
@@ -309,6 +336,11 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2: %s", bSuccess ? "PASS" : "FAIL");
 
+    mpFree(grp0);
+    mpFree(grp1);
+    mpFree(grp2);
+    mpFree(grp3);
+
     return bSuccess;
 }
 
@@ -318,7 +350,7 @@ BOOL Ros_Testing_ControllerStatusIO()
 {
     BOOL bSuccess = TRUE;
 
-// disabled for now, cause controllers to crash (stack overflow issue perhaps?)
+    // disabled for now, cause controllers to crash (stack overflow issue perhaps?)
 #if 0
 
     bSuccess &= Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1();

--- a/src/Tests_ControllerStatusIO.c
+++ b/src/Tests_ControllerStatusIO.c
@@ -84,7 +84,7 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1()
 
     Controller controller;
 
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
     controller.numGroup = 1;
     controller.ctrlGroups[0] = grp0;
 
@@ -99,7 +99,7 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
+    Ros_CtrlGroup_Dtor(grp0);
 
     return bSuccess;
 }
@@ -109,8 +109,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 2;
     controller.ctrlGroups[0] = grp0;
@@ -129,8 +129,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
 
     return bSuccess;
 }
@@ -140,8 +140,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1R2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 2;
     controller.ctrlGroups[0] = grp0;
@@ -159,8 +159,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1R2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1R2: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
 
     return bSuccess;
 }
@@ -170,9 +170,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp2 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 3;
     controller.ctrlGroups[0] = grp0;
@@ -194,9 +194,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
-    mpFree(grp2);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
+    Ros_CtrlGroup_Dtor(grp2);
 
     return bSuccess;
 }
@@ -206,8 +206,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 2;
     controller.ctrlGroups[0] = grp0;
@@ -225,8 +225,8 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
 
     return bSuccess;
 }
@@ -236,9 +236,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1S2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp2 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 3;
     controller.ctrlGroups[0] = grp0;
@@ -258,9 +258,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1S2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1S1S2: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
-    mpFree(grp2);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
+    Ros_CtrlGroup_Dtor(grp2);
 
     return bSuccess;
 }
@@ -270,9 +270,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp2 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 3;
     controller.ctrlGroups[0] = grp0;
@@ -294,9 +294,9 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1S1: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
-    mpFree(grp2);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
+    Ros_CtrlGroup_Dtor(grp2);
 
     return bSuccess;
 }
@@ -306,10 +306,10 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2()
     BOOL bSuccess = TRUE;
 
     Controller controller;
-    CtrlGroup* grp0 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp1 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp2 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
-    CtrlGroup* grp3 = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* grp0 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp1 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp2 = Ros_CtrlGroup_Ctor();
+    CtrlGroup* grp3 = Ros_CtrlGroup_Ctor();
 
     controller.numGroup = 4;
     controller.ctrlGroups[0] = grp0;
@@ -334,10 +334,10 @@ BOOL Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2()
     //report overall result
     Ros_Debug_BroadcastMsg("Testing Ros_Testing_ControllerStatusIO_ShouldWarnNoCalibDataLoaded_R1B1R2B2: %s", bSuccess ? "PASS" : "FAIL");
 
-    mpFree(grp0);
-    mpFree(grp1);
-    mpFree(grp2);
-    mpFree(grp3);
+    Ros_CtrlGroup_Dtor(grp0);
+    Ros_CtrlGroup_Dtor(grp1);
+    Ros_CtrlGroup_Dtor(grp2);
+    Ros_CtrlGroup_Dtor(grp3);
 
     return bSuccess;
 }

--- a/src/Tests_CtrlGroup.c
+++ b/src/Tests_CtrlGroup.c
@@ -92,7 +92,7 @@ void Ros_Testing_CtrlGroup_MakeFakeSiaRobot(CtrlGroup* group)
 
 BOOL Ros_Testing_CtrlGroup_PosConverters()
 {
-    CtrlGroup group;
+    CtrlGroup *group= (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
     long motoPos[MAX_PULSE_AXES];
     double rosPos[MAX_PULSE_AXES];
     BOOL bOk, bAllTestsPassed;
@@ -102,12 +102,12 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
     //-------------------------------------------------------------------------
     // 6 DOF
     //-------------------------------------------------------------------------
-    Ros_Testing_CtrlGroup_MakeFake6dofRobot(&group);
+    Ros_Testing_CtrlGroup_MakeFake6dofRobot(group);
 
     for (int i = 0; i < MAX_PULSE_AXES; i += 1)
         motoPos[i] = (i * 1000) + 2000; //{2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000}
-
-    Ros_CtrlGroup_ConvertToRosPos(&group, motoPos, rosPos);
+    
+    Ros_CtrlGroup_ConvertToRosPos(group, motoPos, rosPos);
 
     bOk = Ros_Testing_CompareDouble(rosPos[0], (2000.0/9.0));
     bOk &= Ros_Testing_CompareDouble(rosPos[1], (3000.0/8.0));
@@ -130,7 +130,7 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
 
     rosPos[6] = rosPos[7] = 123.456; //these two axes are not used. they should get zeroed out in Ros_CtrlGroup_ConvertToMotoPos
 
-    Ros_CtrlGroup_ConvertToMotoPos_FromSequentialOrdering(&group, rosPos, motoPos);
+    Ros_CtrlGroup_ConvertToMotoPos_FromSequentialOrdering(group, rosPos, motoPos);
 
     bOk = Ros_Testing_CompareLong(motoPos[0], 2000);
     bOk &= Ros_Testing_CompareLong(motoPos[1], 3000);
@@ -154,12 +154,12 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
     //-------------------------------------------------------------------------
     // DELTA
     //-------------------------------------------------------------------------
-    Ros_Testing_CtrlGroup_MakeFakeDeltaRobot(&group);
+    Ros_Testing_CtrlGroup_MakeFakeDeltaRobot(group);
 
     for (int i = 0; i < MAX_PULSE_AXES; i += 1)
         motoPos[i] = (i * 1000) + 2000; //{2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000}
 
-    Ros_CtrlGroup_ConvertToRosPos(&group, motoPos, rosPos);
+    Ros_CtrlGroup_ConvertToRosPos(group, motoPos, rosPos);
 
     bOk = Ros_Testing_CompareDouble(rosPos[0], (2000.0 / 9.0));
     bOk &= Ros_Testing_CompareDouble(rosPos[1], (3000.0 / 8.0));
@@ -175,7 +175,7 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
         bAllTestsPassed = FALSE;
     }
 
-    Ros_CtrlGroup_ConvertToMotoPos_FromSequentialOrdering(&group, rosPos, motoPos);
+    Ros_CtrlGroup_ConvertToMotoPos_FromSequentialOrdering(group, rosPos, motoPos);
 
     bOk = Ros_Testing_CompareLong(motoPos[0], 2000);
     bOk &= Ros_Testing_CompareLong(motoPos[1], 3000);
@@ -194,12 +194,12 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
     //-------------------------------------------------------------------------
     // SIA
     //-------------------------------------------------------------------------
-    Ros_Testing_CtrlGroup_MakeFakeSiaRobot(&group);
+    Ros_Testing_CtrlGroup_MakeFakeSiaRobot(group);
 
     for (int i = 0; i < MAX_PULSE_AXES; i += 1)
         motoPos[i] = (i * 1000) + 2000; //{2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000}
 
-    Ros_CtrlGroup_ConvertToRosPos(&group, motoPos, rosPos);
+    Ros_CtrlGroup_ConvertToRosPos(group, motoPos, rosPos);
 
     bOk = Ros_Testing_CompareDouble(rosPos[0], (2000.0 / 9.0));
     bOk &= Ros_Testing_CompareDouble(rosPos[1], (3000.0 / 8.0));
@@ -218,7 +218,7 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
         bAllTestsPassed = FALSE;
     }
 
-    Ros_CtrlGroup_ConvertToMotoPos_FromSequentialOrdering(&group, rosPos, motoPos);
+    Ros_CtrlGroup_ConvertToMotoPos_FromSequentialOrdering(group, rosPos, motoPos);
 
     bOk = Ros_Testing_CompareLong(motoPos[0], 2000);
     bOk &= Ros_Testing_CompareLong(motoPos[1], 3000);
@@ -237,30 +237,34 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
         bAllTestsPassed = FALSE;
     }
 
+    mpFree(group);
+
     return bAllTestsPassed;
 }
 
 BOOL Ros_Testing_CtrlGroup_HasBaseTrack()
 {
-    CtrlGroup group;
+    CtrlGroup* group = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    bzero(group, sizeof(CtrlGroup));
     BOOL bOk, bAllTestsPassed = TRUE;
 
     //no base track
-    group.baseTrackGroupId = (MP_GRP_ID_TYPE)-1;
-    group.baseTrackGroupIndex = -1;
+    group->baseTrackGroupId = (MP_GRP_ID_TYPE)-1;
+    group->baseTrackGroupIndex = -1;
 
-    bOk = Ros_CtrlGroup_HasBaseTrack(&group) == FALSE;
+    bOk = Ros_CtrlGroup_HasBaseTrack(group) == FALSE;
     Ros_Debug_BroadcastMsg("Testing CtrlGroup HasBaseTrack - no base track: %s", bOk ? "PASS" : "FAIL");
     bAllTestsPassed &= bOk;
 
     //has base track: R1+B1
-    group.baseTrackGroupId = MP_B1_GID;
-    group.baseTrackGroupIndex = 1;
+    group->baseTrackGroupId = MP_B1_GID;
+    group->baseTrackGroupIndex = 1;
 
-    bOk = Ros_CtrlGroup_HasBaseTrack(&group) == TRUE;
+    bOk = Ros_CtrlGroup_HasBaseTrack(group) == TRUE;
     Ros_Debug_BroadcastMsg("Testing CtrlGroup HasBaseTrack - base track (B1): %s", bOk ? "PASS" : "FAIL");
     bAllTestsPassed &= bOk;
 
+    mpFree(group);
     return bAllTestsPassed;
 }
 

--- a/src/Tests_CtrlGroup.c
+++ b/src/Tests_CtrlGroup.c
@@ -92,7 +92,7 @@ void Ros_Testing_CtrlGroup_MakeFakeSiaRobot(CtrlGroup* group)
 
 BOOL Ros_Testing_CtrlGroup_PosConverters()
 {
-    CtrlGroup *group= (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup *group= Ros_CtrlGroup_Ctor();
     long motoPos[MAX_PULSE_AXES];
     double rosPos[MAX_PULSE_AXES];
     BOOL bOk, bAllTestsPassed;
@@ -237,14 +237,14 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
         bAllTestsPassed = FALSE;
     }
 
-    mpFree(group);
+    Ros_CtrlGroup_Dtor(group);
 
     return bAllTestsPassed;
 }
 
 BOOL Ros_Testing_CtrlGroup_HasBaseTrack()
 {
-    CtrlGroup* group = (CtrlGroup*)mpMalloc(sizeof(CtrlGroup));
+    CtrlGroup* group = Ros_CtrlGroup_Ctor();
     bzero(group, sizeof(CtrlGroup));
     BOOL bOk, bAllTestsPassed = TRUE;
 
@@ -264,7 +264,7 @@ BOOL Ros_Testing_CtrlGroup_HasBaseTrack()
     Ros_Debug_BroadcastMsg("Testing CtrlGroup HasBaseTrack - base track (B1): %s", bOk ? "PASS" : "FAIL");
     bAllTestsPassed &= bOk;
 
-    mpFree(group);
+    Ros_CtrlGroup_Dtor(group);
     return bAllTestsPassed;
 }
 

--- a/src/Tests_CtrlGroup.c
+++ b/src/Tests_CtrlGroup.c
@@ -245,7 +245,6 @@ BOOL Ros_Testing_CtrlGroup_PosConverters()
 BOOL Ros_Testing_CtrlGroup_HasBaseTrack()
 {
     CtrlGroup* group = Ros_CtrlGroup_Ctor();
-    bzero(group, sizeof(CtrlGroup));
     BOOL bOk, bAllTestsPassed = TRUE;
 
     //no base track

--- a/src/main.c
+++ b/src/main.c
@@ -70,6 +70,7 @@ void RosInitTask()
 
 #ifdef MOTOROS2_TESTING_ENABLE
     Ros_Debug_BroadcastMsg("===");
+    MOTOROS2_MEM_TRACE_START(testing)
     Ros_Debug_BroadcastMsg("Performing unit tests");
     BOOL bTestResult = TRUE;
     bTestResult &= Ros_Testing_CtrlGroup();
@@ -77,6 +78,7 @@ void RosInitTask()
     bTestResult &= Ros_Testing_ControllerStatusIO();
     bTestResult &= Ros_Testing_ActionServer_FJT();
     bTestResult ? Ros_Debug_BroadcastMsg("Testing SUCCESSFUL") : Ros_Debug_BroadcastMsg("!!! Testing FAILED !!!");
+    MOTOROS2_MEM_TRACE_REPORT(testing)
     Ros_Debug_BroadcastMsg("===");
 #endif
 


### PR DESCRIPTION
Among other things, resolves #408

This fixes a bunch of problems with unit tests. Most of the problems were from memory management. 

There was a lot of double allocation or allocating and failing to free memory. 

The reason that it was crashing with the `MOTOROS2_TESTING_ENABLED` flag set (see #407) is because of a stack overflow error. The `CtrlGroup` struct takes up `39392 bytes`, but the default stack size for a thread created via `mpCreateTask(...)` is only `40KB`, so that was getting filled whenever a CtrlGroup was created on the stack. 

With the tests fixed, I also enabled the `Tests_ControllerStatusIO.c` (assuming that `MOTOROS2_TESTING_ENABLED` is set). I am also printing out the dynamic memory lost during testing (should always be 0). 