### PR TITLE
Fixing FJT feedback message

### DIFF
--- a/src/ActionServer_FJT.h
+++ b/src/ActionServer_FJT.h
@@ -8,6 +8,10 @@
 #ifndef MOTOROS2_ACTION_SERVER_FJT_H
 #define MOTOROS2_ACTION_SERVER_FJT_H
 
+#include "MotoROS.h"
+
+#define MAX_CONTROLLABLE_GROUPS             8
+
 #define MAX_NUMBER_OF_POINTS_PER_TRAJECTORY 200
 #define MIN_NUMBER_OF_POINTS_PER_TRAJECTORY 2   //current position and destination
 
@@ -27,7 +31,7 @@ extern void Ros_ActionServer_FJT_ProcessFeedback();
 extern void Ros_ActionServer_FJT_ProcessResult();
 extern bool Ros_ActionServer_FJT_Goal_Cancel(rclc_action_goal_handle_t* goal_handle, void* context);
 
-extern void Ros_ActionServer_FJT_UpdateProgressTracker(MP_EXPOS_DATA* incrementData);
+extern void Ros_ActionServer_FJT_UpdateProgressTracker(MP_PULSE_POS_RSP_DATA pulsePosData[MAX_CONTROLLABLE_GROUPS], MP_EXPOS_DATA* moveData, UINT64 time_executing_trajectory);
 
 
 #endif  // MOTOROS2_ACTION_SERVER_FJT_H

--- a/src/ControllerStatusIO.h
+++ b/src/ControllerStatusIO.h
@@ -28,8 +28,6 @@
 
 #define INVALID_TASK                        -1
 
-#define MAX_CONTROLLABLE_GROUPS             8
-
 #define MASK_ISALARM_ACTIVEALARM            0x02
 #define MASK_ISALARM_ACTIVEERROR            0x01
 

--- a/src/MotionControl.h
+++ b/src/MotionControl.h
@@ -42,4 +42,6 @@ extern BOOL Ros_MotionControl_IsMotionMode_RawStreaming();
 
 extern void Ros_MotionControl_ValidateMotionModeIsOk();
 
+extern int64_t Ros_MotionControl_TrajectoryExecutionStartTime;
+
 #endif  // MOTOROS2_MOTION_CONTROL_H


### PR DESCRIPTION
This has ended up being less straightforward than I was expecting, so I'm putting this out there as a draft and will make any requested modifications, clean everything up, and break it into different commits before finalizing the PR. 

First, I realized that the way that we handle FSU/accept that slowdowns can happen will make this difficult. When populating the `desired` feedback, it is difficult to choose what point to use. Specifically for a trajectory that "falls behind", do we want desired to be the most recently commanded position, or what position "should be commanded" at this time (if there was no slowdown). I would like to do the latter, but unfortunately if there is a slowdown, the increment point queue can quickly fill up and the position that "should be commanded" may not have been calculated yet. The increment queue has a max length of 200 points, or less than a second in time so that will likely happen if there is an FSU. We could increase that queue size, but the problem remains. I don't think that we could make the queue "big enough" to not worry. Plus if we do what "should" be commanded, that may make the code more complicated since we would have to traverse the increment queue separately. So I am reporting what currently is commanded as `desired`, instead, even if it doesn't match up perfectly with the request. This should only really matter if there is an FSU.

Second, desired and actual feedback messages are populated in two separate threads, so the `time_from_start` in reality going to be different between the two. So error can't be "properly" calculated. Right now I am just subtracting the most recent actual from desired, and the time differences are small enough that I don't feel it really matters, plus there's not much that can be done. If anybody would prefer a different method for populating `time_from_start`, let me know. 

Third, for `desired` `time_from_start`, at the end of a motion while waiting for the feedback to catch up, do we want to continue incrementing the `time_from_start` in the message? Or just leave it? E.g. say the `time_from_start` of the last point in the FJT request is `1 sec`, but the trajectory takes 1.3 seconds to complete. At `1.2 sec`, do we want desired to say `time_from_start` is `1.2 sec`, or `1 sec`? 

Fourth, which values (`position`, `velocity`, `acceleration`, `effort`) do we want to be populated for each of the point types (`actual`, `desired`, `error`)? For now, I was planning on having `position` and `velocity` for all three, skipping `acceleration` (like we do for `joint_states`), and only having `effort` for actual, because calculating the `desired` effort is difficult and we don't respect the effort submitted by the user in the FJT. 