### PR TITLE
Updated MotoROS2 configuration update instructions for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ In *Normal Operation* mode:
  1. touch `[EX MEMORY]`→`[Load]`
  1. cursor to `USER DEFINED FILES` and press `[SELECT]`
  1. cursor to `motoros2_config.yaml` and press `[SELECT]` then `[ENTER]`
- 1. touch `[YES]` to overwrite
+ 1. touch `[EXECUTE]` and press `[YES]` to overwrite
  1. reboot the robot controller
 
 ##### Older controller software


### PR DESCRIPTION
While going through the instructions to update an existing MotoROS2 configuration, I found it would be helpful to specify that the EXECUTE button on the pendant needed to be pressed before pressing YES to overwrite the configuration file.