### PR TITLE
Kilted support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,6 +349,9 @@ healthchecksdb
 .vscode/
 
 # M+ libmicroros distribution directories
+libmicroros_yrc1000_kilted/
+libmicroros_yrc1000u_kilted/
+libmicroros_dx200_kilted/
 libmicroros_yrc1000_jazzy/
 libmicroros_yrc1000u_jazzy/
 libmicroros_dx200_jazzy/

--- a/MotoROS2.sln
+++ b/MotoROS2.sln
@@ -11,14 +11,17 @@ Global
 		DX200_galactic|x86 = DX200_galactic|x86
 		DX200_humble|x86 = DX200_humble|x86
 		DX200_jazzy|x86 = DX200_jazzy|x86
+		DX200_kilted|x86 = DX200_kilted|x86
 		YRC1000_foxy|x86 = YRC1000_foxy|x86
 		YRC1000_galactic|x86 = YRC1000_galactic|x86
 		YRC1000_humble|x86 = YRC1000_humble|x86
 		YRC1000_jazzy|x86 = YRC1000_jazzy|x86
+		YRC1000_kilted|x86 = YRC1000_kilted|x86
 		YRC1000u_foxy|x86 = YRC1000u_foxy|x86
 		YRC1000u_galactic|x86 = YRC1000u_galactic|x86
 		YRC1000u_humble|x86 = YRC1000u_humble|x86
 		YRC1000u_jazzy|x86 = YRC1000u_jazzy|x86
+		YRC1000u_kilted|x86 = YRC1000u_kilted|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{64C31524-A3C4-49D4-AD04-955D44202226}.DX200_foxy|x86.ActiveCfg = DX200_foxy|Win32
@@ -29,6 +32,8 @@ Global
 		{64C31524-A3C4-49D4-AD04-955D44202226}.DX200_humble|x86.Build.0 = DX200_humble|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.DX200_jazzy|x86.ActiveCfg = DX200_jazzy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.DX200_jazzy|x86.Build.0 = DX200_jazzy|Win32
+		{64C31524-A3C4-49D4-AD04-955D44202226}.DX200_kilted|x86.ActiveCfg = DX200_kilted|Win32
+		{64C31524-A3C4-49D4-AD04-955D44202226}.DX200_kilted|x86.Build.0 = DX200_kilted|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_foxy|x86.ActiveCfg = YRC1000_foxy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_foxy|x86.Build.0 = YRC1000_foxy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_galactic|x86.ActiveCfg = YRC1000_galactic|Win32
@@ -37,6 +42,8 @@ Global
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_humble|x86.Build.0 = YRC1000_humble|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_jazzy|x86.ActiveCfg = YRC1000_jazzy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_jazzy|x86.Build.0 = YRC1000_jazzy|Win32
+		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_kilted|x86.ActiveCfg = YRC1000_kilted|Win32
+		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000_kilted|x86.Build.0 = YRC1000_kilted|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_foxy|x86.ActiveCfg = YRC1000u_foxy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_foxy|x86.Build.0 = YRC1000u_foxy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_galactic|x86.ActiveCfg = YRC1000u_galactic|Win32
@@ -45,6 +52,8 @@ Global
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_humble|x86.Build.0 = YRC1000u_humble|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_jazzy|x86.ActiveCfg = YRC1000u_jazzy|Win32
 		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_jazzy|x86.Build.0 = YRC1000u_jazzy|Win32
+		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_kilted|x86.ActiveCfg = YRC1000u_kilted|Win32
+		{64C31524-A3C4-49D4-AD04-955D44202226}.YRC1000u_kilted|x86.Build.0 = YRC1000u_kilted|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The following general requirements must be met in order to be able to use MotoRO
 - the controller must have a correctly configured network connection:
   - DX200 and YRC1000micro: `LAN`
   - YRC1000: either `LAN2` or `LAN3`
-- ROS 2 version: Foxy, Galactic, Humble, or Jazzy.
+- ROS 2 version: Foxy, Galactic, Humble, Jazzy, or Kilted.
   MotoROS2 does not support ROS 2 Iron Irwini nor Rolling Ridley.
 - Docker or a from-source build of the micro-ROS Agent
 - FastDDS as RMW (even when using ROS 2 Galactic)
@@ -174,10 +174,13 @@ The values must match *exactly*.
 |:--------------|:-----------------|:------------------|:-----------|:-----------------------------------|
 | DX200         | Humble           | `mr2_dx2_h.out`   | `0.2.1`    | `6672e218b60c42f00ce335dc4a977ee9` |
 | DX200         | Jazzy            | `mr2_dx2_j.out`   | `0.2.1`    | `f31673a8559e331719f8b25f174419a3` |
+| DX200         | Kilted           | `mr2_dx2_k.out`   | `0.2.1`    | ` `                                |
 | YRC1000       | Humble           | `mr2_yrc1_h.out`  | `0.2.1`    | `fec0137dc4b3dd4b9c5e169d78211eda` |
 | YRC1000       | Jazzy            | `mr2_yrc1_j.out`  | `0.2.1`    | `6b7c0cae3e13f266509615412e46e57b` |
+| YRC1000       | Kilted           | `mr2_yrc1_k.out`  | `0.2.1`    | ` `                                |
 | YRC1000micro  | Humble           | `mr2_yrc1m_h.out` | `0.2.1`    | `6666de4b1bb41859a543f5ca8a413a98` |
 | YRC1000micro  | Jazzy            | `mr2_yrc1m_j.out` | `0.2.1`    | `c421fa95d647ab77a5f2a1babed06fa2` |
+| YRC1000micro  | Kilted           | `mr2_yrc1m_k.out` | `0.2.1`    | ` `                                |
 
 If the hash matches, proceed with the next section, [Installation](#installation).
 
@@ -443,6 +446,7 @@ However, always make sure to use a version of the Agent image which corresponds 
 With ROS 2 Foxy, use `microros/micro-ros-agent:foxy`.
 With ROS 2 Humble, use `microros/micro-ros-agent:humble`.
 With ROS 2 Jazzy, use `microros/micro-ros-agent:jazzy`.
+With ROS 2 Kilted, use `microros/micro-ros-agent:kilted`.
 
 To start the Agent (on a machine with Docker already installed and setup to allow non-root access):
 
@@ -470,6 +474,7 @@ Note: always make sure to use a version of the Agent which corresponds to the ve
 For ROS 2 Foxy, checkout the `foxy` branch.
 For ROS 2 Humble, checkout the `humble` branch.
 For ROS 2 Jazzy, checkout the `jazzy` branch.
+For ROS 2 Kilted, checkout the `kilted` branch.
 
 #### Linux (Debian/Ubuntu)
 
@@ -559,7 +564,7 @@ After the final reboot of the controller, and after [starting the micro-ROS Agen
 
 Note: if you are using ROS 2 Galactic, please first read [Only FastDDS is supported](#only-fastdds-is-supported).
 
-On a PC with a supported ROS 2 installation (ie: Foxy, Galactic (with FastDDS), Humble, or Jazzy):
+On a PC with a supported ROS 2 installation (ie: Foxy, Galactic (with FastDDS), Humble, Jazzy, or Kilted):
 
 1. open a new terminal
 1. `source` the ROS 2 installation
@@ -749,7 +754,7 @@ None of the other RMWs are supported, including Cyclone DDS, which is the defaul
 
 Symptoms of this incompatibility are seemingly functional ROS 2 network connections, where topics are succesfully published and subscribed to, but service invocations and action goal submissions appear to *hang*.
 
-**Note**: ROS 2 Foxy, ROS 2 Humble, ROS 2 Jazzy, and ROS 2 Rolling all use FastDDS by default.
+**Note**: ROS 2 Foxy, ROS 2 Humble, ROS 2 Jazzy, ROS 2 Kilted, and ROS 2 Rolling all use FastDDS by default.
 If you haven't changed your default RMW, you should not need to change anything for MotoROS2.
 
 **Work-around**: unfortunately, this limitation is caused by a middleware-layer incompatibility with respect to how service requests are (de)serialised by the respective RMWs ([ros2/rmw_cyclonedds#184](https://github.com/ros2/rmw_cyclonedds/issues/184)), and without significant changes to the way MotoROS2 operates, has no known work-around.

--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ To start the Agent (on a machine with Docker already installed and setup to allo
 docker run \
   -it \
   --rm \
+  --ipc=host \
   --net=host \
   --user=$(id -u):$(id -g) \
   microros/micro-ros-agent:jazzy \

--- a/doc/build_from_source.md
+++ b/doc/build_from_source.md
@@ -21,7 +21,7 @@ The MotoPlus SDK is not compatible with Visual Studio Code.
 - **MotoPlus SDK for Visual Studio v1.5.1 or higher**.
 This is not the same as MotoPlus IDE. Users in Asian regions will need to purchase this software from [Yaskawa America directly](https://www.motoman.com/en-us/products/robots/sales-quote).
 If you already have a license for an older version of the MotoPlus SDK, please contact `techsupport@motoman.com` or `ccs@yaskawa.eu` for assistance obtaining a newer edition.
-- **libmicroros library and headers** that corresponds to your target edition of ROS 2 (Humble, Jazzy, etc) and the Yaskawa controller series you are building MotoROS2 for
+- **libmicroros library and headers** that corresponds to your target edition of ROS 2 (Humble, Jazzy, Kilted, etc) and the Yaskawa controller series you are building MotoROS2 for
 Although `libmicroros` as used by MotoROS2 is derived from the open-source [micro-ROS](https://micro.ros.org) project, various patches were needed to make it compatible with MotoPlus. As of writing, these patches can not be made open-source yet. Because of this, we distribute the `libmicroros` dependency as a closed-source library.
 These can be found on the [micro_ros_motoplus/Releases](https://github.com/yaskawa-global/micro_ros_motoplus/releases) page.
 

--- a/src/CommunicationExecutor.c
+++ b/src/CommunicationExecutor.c
@@ -290,7 +290,7 @@ void Ros_Communication_StartExecutors(SEM_ID semCommunicationExecutorStatus)
     // rclc_timer_init_default(..) was replaced with rclc_timer_init_default2(..)
     // in Jazzy, which has a different set of parameters. Call the correct version
     // based on what this is being compiled for
-#ifdef MOTOPLUS_LIBMICROROS_ROS2_IS_JAZZY
+#if defined(MOTOPLUS_LIBMICROROS_ROS2_IS_JAZZY) || defined(MOTOPLUS_LIBMICROROS_ROS2_IS_KILTED)
     rc = rclc_timer_init_default2(&timerPingAgent, &g_microRosNodeInfo.support, RCL_MS_TO_NS(PERIOD_COMMUNICATION_PING_AGENT_MS), Ros_Communication_PingAgentConnection, true);
     motoRosAssert_withMsg(rc == RCL_RET_OK, SUBCODE_FAIL_TIMER_INIT_PING, "Failed creating rclc timer (%d)", (int)rc);
 

--- a/src/DX200_kiltedCompilerArguments.mps
+++ b/src/DX200_kiltedCompilerArguments.mps
@@ -1,0 +1,1 @@
+-DDX200 -DMOTOROS2_MEM_TRACE_ENABLE -std=gnu99 -march=atom -nostdlib -fno-builtin -fno-defer-pop -fno-implicit-fp -fno-zero-initialized-in-bss -Wall -Werror-implicit-function-declaration -DCPU=_VX_ATOM -DTOOL_FAMILY=gnu -DTOOL=gnu -D_WRS_KERNEL -I "~ProjectDir~" ~AdditionalIncludeDir~ -isystem "~IncludeDir~" -O0 ~ObjFileInfo~ -c "~FilePath~"

--- a/src/DX200_kiltedLinkerArguments.mps
+++ b/src/DX200_kiltedLinkerArguments.mps
@@ -1,0 +1,1 @@
+-std=gnu99 -nostdlib -r -Wl,--discard-locals -Wl,--entry=mpUsrRoot ~FileList~ -o "~OutputPath~"

--- a/src/MotoROS2_AllControllers.vcxproj
+++ b/src/MotoROS2_AllControllers.vcxproj
@@ -17,6 +17,10 @@
       <Configuration>DX200_jazzy</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="DX200_kilted|Win32">
+      <Configuration>DX200_kilted</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="YRC1000u_foxy|Win32">
       <Configuration>YRC1000u_foxy</Configuration>
       <Platform>Win32</Platform>
@@ -31,6 +35,10 @@
     </ProjectConfiguration>
     <ProjectConfiguration Include="YRC1000u_jazzy|Win32">
       <Configuration>YRC1000u_jazzy</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="YRC1000u_kilted|Win32">
+      <Configuration>YRC1000u_kilted</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="YRC1000_foxy|Win32">
@@ -49,6 +57,10 @@
       <Configuration>YRC1000_jazzy</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="YRC1000_kilted|Win32">
+      <Configuration>YRC1000_kilted</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{64C31524-A3C4-49D4-AD04-955D44202226}</ProjectGuid>
@@ -59,6 +71,11 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DX200_jazzy|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DX200_kilted|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
@@ -83,6 +100,11 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_kilted|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_humble|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -99,6 +121,11 @@
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_jazzy|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_kilted|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
@@ -124,6 +151,9 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DX200_jazzy|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DX200_kilted|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DX200_humble|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -136,6 +166,9 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_jazzy|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_kilted|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_humble|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -146,6 +179,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_jazzy|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_kilted|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_humble|Win32'" Label="PropertySheets">
@@ -169,6 +205,18 @@
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir />
     <IncludePath>$(ProjectDir)..\lib;$(ProjectDir)..\libmicroros_dx200_jazzy\include;</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DX200_kilted|Win32'">
+    <NMakeBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_dx2_k" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)DX200\inc"</NMakeBuildCommandLine>
+    <NMakeOutput>$(MP_VS_Install)DevTools\OnlineDownload.exe</NMakeOutput>
+    <NMakePreprocessorDefinitions>$(NMakePreprocessorDefinitions);DX200;MOTOROS2_MEM_TRACE_ENABLE</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(MP_VS_Install)DX200\gnu\4.3.3-vxworks-6.9\lib\gcc\i586-wrs-vxworks\4.3.3\include;$(MP_VS_Install)DX200\inc;$(SolutionDir)libmicroros_dx200_kilted\include;</NMakeIncludeSearchPath>
+    <NMakeReBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_dx2_k" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)DX200\inc"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_dx2_k" -b "$(OutDir)\" -o clean</NMakeCleanCommandLine>
+    <NMakeForcedIncludes />
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir />
+    <IncludePath>$(ProjectDir)..\lib;$(ProjectDir)..\libmicroros_dx200_kilted\include;</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DX200_humble|Win32'">
     <NMakeBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_dx2_h" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)DX200\inc"</NMakeBuildCommandLine>
@@ -218,6 +266,18 @@
     <IntDir />
     <IncludePath>$(ProjectDir)..\lib;$(ProjectDir)..\libmicroros_yrc1000_jazzy\include;</IncludePath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_kilted|Win32'">
+    <NMakeBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1_k" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)YRC1000\inc"</NMakeBuildCommandLine>
+    <NMakeOutput>$(MP_VS_Install)DevTools\OnlineDownload.exe</NMakeOutput>
+    <NMakePreprocessorDefinitions>$(NMakePreprocessorDefinitions);YRC1000;MOTOROS2_MEM_TRACE_ENABLE</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(MP_VS_Install)YRC1000\gnu\4.3.3-vxworks-6.9\lib\gcc\i586-wrs-vxworks\4.3.3\include;$(MP_VS_Install)YRC1000\inc;$(SolutionDir)libmicroros_yrc1000_kilted\include;</NMakeIncludeSearchPath>
+    <NMakeReBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1_k" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)YRC1000\inc"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1_k" -b "$(OutDir)\" -o clean</NMakeCleanCommandLine>
+    <NMakeForcedIncludes />
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir />
+    <IncludePath>$(ProjectDir)..\lib;$(ProjectDir)..\libmicroros_yrc1000_kilted\include;</IncludePath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_humble|Win32'">
     <NMakeBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1_h" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)YRC1000\inc"</NMakeBuildCommandLine>
     <NMakeOutput>$(MP_VS_Install)DevTools\OnlineDownload.exe</NMakeOutput>
@@ -266,6 +326,18 @@
     <IntDir />
     <IncludePath>$(ProjectDir)..\lib;$(ProjectDir)..\libmicroros_yrc1000u_jazzy\include;</IncludePath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_kilted|Win32'">
+    <NMakeBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1m_k" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)YRC1000u\inc"</NMakeBuildCommandLine>
+    <NMakeOutput>$(MP_VS_Install)DevTools\OnlineDownload.exe</NMakeOutput>
+    <NMakePreprocessorDefinitions>$(NMakePreprocessorDefinitions);YRC1000u;MOTOROS2_MEM_TRACE_ENABLE</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(MP_VS_Install)YRC1000u\gnu\4.3.3-vxworks-6.9\lib\gcc\i586-wrs-vxworks\4.3.3\include;$(MP_VS_Install)YRC1000u\inc;$(SolutionDir)libmicroros_yrc1000u_kilted\include;</NMakeIncludeSearchPath>
+    <NMakeReBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1m_k" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)YRC1000u\inc"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1m_k" -b "$(OutDir)\" -o clean</NMakeCleanCommandLine>
+    <NMakeForcedIncludes />
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir />
+    <IncludePath>$(ProjectDir)..\lib;$(ProjectDir)..\libmicroros_yrc1000u_kilted\include;</IncludePath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_humble|Win32'">
     <NMakeBuildCommandLine>"$(MP_VS_Install)mpBuilder.exe" -c $(Configuration) -p "$(ProjectDir)\" -n "mr2_yrc1m_h" -b "$(SolutionDir)bin\$(Configuration)" -o build -i "$(MP_VS_Install)YRC1000u\inc"</NMakeBuildCommandLine>
     <NMakeOutput>$(MP_VS_Install)DevTools\OnlineDownload.exe</NMakeOutput>
@@ -307,6 +379,11 @@
       <Path>_buildLog\MotoROS2$(Configuration).log</Path>
     </BuildLog>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DX200_kilted|Win32'">
+    <BuildLog>
+      <Path>_buildLog\MotoROS2$(Configuration).log</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DX200_humble|Win32'">
     <BuildLog>
       <Path>_buildLog\MotoROS2$(Configuration).log</Path>
@@ -327,6 +404,11 @@
       <Path>_buildLog\MotoROS2$(Configuration).log</Path>
     </BuildLog>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_kilted|Win32'">
+    <BuildLog>
+      <Path>_buildLog\MotoROS2$(Configuration).log</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000_humble|Win32'">
     <BuildLog>
       <Path>_buildLog\MotoROS2$(Configuration).log</Path>
@@ -343,6 +425,11 @@
     </BuildLog>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_jazzy|Win32'">
+    <BuildLog>
+      <Path>_buildLog\MotoROS2$(Configuration).log</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='YRC1000u_kilted|Win32'">
     <BuildLog>
       <Path>_buildLog\MotoROS2$(Configuration).log</Path>
     </BuildLog>
@@ -372,15 +459,18 @@
     <None Include="..\libmicroros_dx200_galactic\libmicroros.dnLib_galactic" />
     <None Include="..\libmicroros_dx200_humble\libmicroros.dnLib_humble" />
     <None Include="..\libmicroros_dx200_jazzy\libmicroros.dnLib_jazzy" />
+    <None Include="..\libmicroros_dx200_kilted\libmicroros.dnLib_kilted" />
     <None Include="..\libmicroros_yrc1000u_foxy\libmicroros.yrcmLib_foxy" />
     <None Include="..\libmicroros_yrc1000u_galactic\libmicroros.yrcmLib_galactic" />
     <None Include="..\libmicroros_yrc1000u_humble\libmicroros.yrcmLib_humble" />
     <None Include="..\libmicroros_yrc1000u_jazzy\libmicroros.yrcmLib_jazzy" />
+    <None Include="..\libmicroros_yrc1000u_kilted\libmicroros.yrcmLib_kilted" />
     <None Include="..\libmicroros_yrc1000_foxy\libmicroros.yrcLib_foxy" />
     <None Include="..\libmicroros_yrc1000_galactic\libmicroros.yrcLib_galactic" />
     <None Include="..\libmicroros_yrc1000_humble\libmicroros.yrcLib_humble" />
     <None Include="..\config\motoros2_config.yaml" />
     <None Include="..\libmicroros_yrc1000_jazzy\libmicroros.yrcLib_jazzy" />
+    <None Include="..\libmicroros_yrc1000_kilted\libmicroros.yrcLib_kilted" />
     <None Include="DX200_foxyCompilerArguments.mps" />
     <None Include="DX200_foxyLinkerArguments.mps" />
     <None Include="DX200_galacticCompilerArguments.mps" />
@@ -407,6 +497,8 @@
     <None Include="DX200_humbleLinkerArguments.mps" />
     <None Include="DX200_jazzyCompilerArguments.mps" />
     <None Include="DX200_jazzyLinkerArguments.mps" />
+    <None Include="DX200_kiltedCompilerArguments.mps" />
+    <None Include="DX200_kiltedLinkerArguments.mps" />
     <None Include="YRC1000u_foxyCompilerArguments.mps" />
     <None Include="YRC1000u_foxyLinkerArguments.mps" />
     <None Include="YRC1000u_galacticCompilerArguments.mps" />
@@ -415,6 +507,8 @@
     <None Include="YRC1000u_humbleLinkerArguments.mps" />
     <None Include="YRC1000u_jazzyCompilerArguments.mps" />
     <None Include="YRC1000u_jazzyLinkerArguments.mps" />
+    <None Include="YRC1000u_kiltedCompilerArguments.mps" />
+    <None Include="YRC1000u_kiltedLinkerArguments.mps" />
     <None Include="YRC1000_foxyCompilerArguments.mps" />
     <None Include="YRC1000_foxyLinkerArguments.mps" />
     <None Include="YRC1000_galacticCompilerArguments.mps" />
@@ -423,6 +517,8 @@
     <None Include="YRC1000_humbleLinkerArguments.mps" />
     <None Include="YRC1000_jazzyCompilerArguments.mps" />
     <None Include="YRC1000_jazzyLinkerArguments.mps" />
+    <None Include="YRC1000_kiltedCompilerArguments.mps" />
+    <None Include="YRC1000_kiltedLinkerArguments.mps" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CommunicationExecutor.c" />

--- a/src/MotoROS2_AllControllers.vcxproj.filters
+++ b/src/MotoROS2_AllControllers.vcxproj.filters
@@ -277,6 +277,33 @@
     <None Include="..\libmicroros_yrc1000u_jazzy\libmicroros.yrcmLib_jazzy">
       <Filter>MotoPlus Libraries\micro-ROS</Filter>
     </None>
+    <None Include="DX200_kiltedCompilerArguments.mps">
+      <Filter>Compile Settings</Filter>
+    </None>
+    <None Include="DX200_kiltedLinkerArguments.mps">
+      <Filter>Compile Settings</Filter>
+    </None>
+    <None Include="YRC1000_kiltedLinkerArguments.mps">
+      <Filter>Compile Settings</Filter>
+    </None>
+    <None Include="YRC1000_kiltedCompilerArguments.mps">
+      <Filter>Compile Settings</Filter>
+    </None>
+    <None Include="YRC1000u_kiltedCompilerArguments.mps">
+      <Filter>Compile Settings</Filter>
+    </None>
+    <None Include="YRC1000u_kiltedLinkerArguments.mps">
+      <Filter>Compile Settings</Filter>
+    </None>
+    <None Include="..\libmicroros_yrc1000_kilted\libmicroros.yrcLib_kilted">
+      <Filter>MotoPlus Libraries\micro-ROS</Filter>
+    </None>
+    <None Include="..\libmicroros_dx200_kilted\libmicroros.dnLib_kilted">
+      <Filter>MotoPlus Libraries\micro-ROS</Filter>
+    </None>
+    <None Include="..\libmicroros_yrc1000u_kilted\libmicroros.yrcmLib_kilted">
+      <Filter>MotoPlus Libraries\micro-ROS</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.c">

--- a/src/YRC1000_kiltedCompilerArguments.mps
+++ b/src/YRC1000_kiltedCompilerArguments.mps
@@ -1,0 +1,1 @@
+-DYRC1000 -DMOTOROS2_MEM_TRACE_ENABLE -std=gnu99 -march=atom -nostdlib -fno-builtin -fno-defer-pop -fno-implicit-fp -fno-zero-initialized-in-bss -Wall -Werror-implicit-function-declaration -DCPU=_VX_ATOM -DTOOL_FAMILY=gnu -DTOOL=gnu -D_WRS_KERNEL -I "~ProjectDir~" ~AdditionalIncludeDir~ -isystem "~IncludeDir~" -O0 ~ObjFileInfo~ -c "~FilePath~"

--- a/src/YRC1000_kiltedLinkerArguments.mps
+++ b/src/YRC1000_kiltedLinkerArguments.mps
@@ -1,0 +1,1 @@
+-std=gnu99 -nostdlib -r -Wl,--discard-locals -Wl,--entry=mpUsrRoot ~FileList~ -o "~OutputPath~"

--- a/src/YRC1000u_kiltedCompilerArguments.mps
+++ b/src/YRC1000u_kiltedCompilerArguments.mps
@@ -1,0 +1,1 @@
+-DYRC1000u -DMOTOROS2_MEM_TRACE_ENABLE -std=gnu99 -march=atom -nostdlib -fno-builtin -fno-defer-pop -fno-implicit-fp -fno-zero-initialized-in-bss -Wall -Werror-implicit-function-declaration -DCPU=_VX_ATOM -DTOOL_FAMILY=gnu -DTOOL=gnu -D_WRS_KERNEL -I "~ProjectDir~" ~AdditionalIncludeDir~ -isystem "~IncludeDir~" -O0 ~ObjFileInfo~ -c "~FilePath~"

--- a/src/YRC1000u_kiltedLinkerArguments.mps
+++ b/src/YRC1000u_kiltedLinkerArguments.mps
@@ -1,0 +1,1 @@
+-std=gnu99 -nostdlib -r -Wl,--discard-locals -Wl,--entry=mpUsrRoot ~FileList~ -o "~OutputPath~"

--- a/src/controllers.xml
+++ b/src/controllers.xml
@@ -5,6 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <root>
 	<libExtension>
+		<YRC1000_kilted>yrcLib_kilted;yrcLib</YRC1000_kilted>
+		<YRC1000u_kilted>yrcmLib_kilted;yrcmLib</YRC1000u_kilted>
+		<DX200_kilted>dnLib_kilted;dnLib</DX200_kilted>
 		<YRC1000_jazzy>yrcLib_jazzy;yrcLib</YRC1000_jazzy>
 		<YRC1000u_jazzy>yrcmLib_jazzy;yrcmLib</YRC1000u_jazzy>
 		<DX200_jazzy>dnLib_jazzy;dnLib</DX200_jazzy>
@@ -20,6 +23,9 @@ SPDX-License-Identifier: Apache-2.0
 	</libExtension>
 	
 	<appName>
+		<YRC1000_kilted>MOTOPLUS-YRC1000</YRC1000_kilted>
+		<YRC1000u_kilted>MOTOPLUS-YRC1000micro</YRC1000u_kilted>
+		<DX200_kilted>MOTOPLUS-DX200</DX200_kilted>
 		<YRC1000_jazzy>MOTOPLUS-YRC1000</YRC1000_jazzy>
 		<YRC1000u_jazzy>MOTOPLUS-YRC1000micro</YRC1000u_jazzy>
 		<DX200_jazzy>MOTOPLUS-DX200</DX200_jazzy>
@@ -35,6 +41,9 @@ SPDX-License-Identifier: Apache-2.0
 	</appName>
 	
 	<compilers>
+		<YRC1000_kilted>YRC1000\gnu\4.3.3-vxworks-6.9\x86-win32\bin\ccpentium.exe</YRC1000_kilted>
+		<YRC1000u_kilted>YRC1000u\gnu\4.3.3-vxworks-6.9\x86-win32\bin\ccpentium.exe</YRC1000u_kilted>
+		<DX200_kilted>DX200\gnu\4.3.3-vxworks-6.9\x86-win32\bin\ccpentium.exe</DX200_kilted>
 		<YRC1000_jazzy>YRC1000\gnu\4.3.3-vxworks-6.9\x86-win32\bin\ccpentium.exe</YRC1000_jazzy>
 		<YRC1000u_jazzy>YRC1000u\gnu\4.3.3-vxworks-6.9\x86-win32\bin\ccpentium.exe</YRC1000u_jazzy>
 		<DX200_jazzy>DX200\gnu\4.3.3-vxworks-6.9\x86-win32\bin\ccpentium.exe</DX200_jazzy>


### PR DESCRIPTION
Adds kilted support. 

Depends on https://github.com/Yaskawa-Global/micro_ros_motoplus/pull/22 (and consequently https://github.com/Yaskawa-Global/micro_ros_motoplus/pull/21) and https://github.com/Yaskawa-Global/micro_ros_motoplus_buildscripts/pull/167. 

I added `--ipc=host` to the docker run example because otherwise the micro-ros agent wasn't publishing properly. I could list topics and nodes, but not echo. But after adding `--ipc=host`, it worked. 

I haven't thoroughly tested. I loaded on a binary that I built and verified that `/joint_states` was publishing.

I don't know when Lyrical will make it upstream for micro-ros, but hopefully having done all of this will make it easier to port once it does come. 