### PR TITLE
ci: use CI token for u-ROS M+ download

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -83,19 +83,10 @@ jobs:
     - name: Find MSBuild and add to PATH
       uses: microsoft/setup-msbuild@v3
 
-    - name: Generate token (micro_ros_motoplus)
-      id: gen_token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ secrets.MPLMB_APP_ID }}
-        private-key: ${{ secrets.MPLMB_APP_PRIVATE_KEY }}
-        owner: "yaskawa-global"
-        repositories: "micro_ros_motoplus"
-
     - name: "Download M+ libmicroros (${{ matrix.uros.codename }}-${{ matrix.uros.release }} for ${{ steps.uppercaser.outputs.ctrlr }})"
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ steps.gen_token.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
         RELEASE_TYPE: ${{ (matrix.uros.prerelease && 'prerelease') || 'release' }}
       run: |
         gh \


### PR DESCRIPTION
As per title.

This switches the MSBuild CI workflow to use a regular `github.token` instead of a special token we acquire using `actions/create-github-app-token`.

We previously used that action because `yaskawa-global/micro_ros_motoplus` was a private repository, but that is no longer the case.

See [runs/29005919982](https://github.com/Yaskawa-Global/motoros2/actions/runs/29005919982) for a test run with this change (ignore the failed jobs, they're failing for a different reason -- the `Download M+ libmicroros` step is successful, which is what this PR changes).
