### PR TITLE
ci: switch to Bash for SDK download

### DIFF
--- a/.github/workflows/ci_msbuild.yaml
+++ b/.github/workflows/ci_msbuild.yaml
@@ -122,11 +122,11 @@ jobs:
           -d /c/build/motoros2/libmicroros_${{ matrix.controller }}_${{ matrix.uros.codename }}
 
     - name: Download and setup M+ SDK (mpBuilder)
-      shell: cmd
+      shell: bash
       run: |
-        C:\msys64\usr\bin\wget.exe -q -O C:/build/mpsdk_ci.7z "${{ secrets.MPSDK_DOWNLOAD_URL }}"
-        "C:\Program Files\7-Zip\7z.exe" x C:/build/mpsdk_ci.7z -oC:/build/
-        del /q C:\build\mpsdk_ci.7z
+        curl -Ls --output-dir=/c/build -o mpsdk_ci.7z '${{ secrets.MPSDK_DOWNLOAD_URL }}'
+        7z x /c/build/mpsdk_ci.7z -o"/c/build/"
+        rm -f /c/build/mpsdk_ci.7z
     - name: Add M+ SDK to PATH
       shell: bash
       run: echo "C:/build/mpsdk" >> $GITHUB_PATH


### PR DESCRIPTION
As per title.

Bash -- as a shell -- has better support for exit-early behaviour in case commands fail.

Windows Cmd does not.

This also switches to `curl` (from `wget`) as that's more universally available on the runners it seems.
